### PR TITLE
[10] Introduce 2 stage model for volition refernce

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,9 @@ project('api'){
     dependencies {
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
         compile 'javax.annotation:javax.annotation-api:1.3.2'
+        compile 'com.google.guava:guava:27.0.1-jre'
     }
-
+  
     ext {
         volitionName = "volition-api"
         volitionVersion = '0.2'

--- a/csharp-client-reference/MainWindow.xaml.cs
+++ b/csharp-client-reference/MainWindow.xaml.cs
@@ -88,12 +88,17 @@ namespace EmpowerOps.Volition.RefClient
                 {
                     HandleRequestAsync(requestsResponseStream.Current);
                 }
-                Log("- Query Stream Closed, unregister");
-                Unregister();
+
+                Log("- Query Closed, plugin has been unregisred by server");
             }
             catch (Exception e)
             {
                 Log($"- Error happened when reading from request stream, unregistered\n{e}");
+            }
+            finally
+            {
+                _name = "";
+                _requests = null;
                 _isRegistered = false;
                 UpdateButton();
             }
@@ -309,6 +314,11 @@ namespace EmpowerOps.Volition.RefClient
             //TODO better error state handing, when register failed due to no connection, it is not well though right now
             //TODO also when error flow when register e.g. same name
             var registrationCommandDto = new RegistrationCommandDTO {Name = RegName.Text };
+            if (_requests != null)
+            {
+                Log("- Node already registered");
+                return;
+            }
 
             Log($"- Try Register as {RegName.Text}");
             _requests = _client.register(registrationCommandDto);
@@ -316,7 +326,7 @@ namespace EmpowerOps.Volition.RefClient
             {
                 await _channel.WaitForStateChangedAsync(_channel.State);
             }
-            
+
             if (_channel.State == ChannelState.Ready)
             {
                 Log("- Registered");
@@ -421,6 +431,7 @@ namespace EmpowerOps.Volition.RefClient
             var message = (responseDto.Unregistered ? "Successful" : "Failed");
             Log($"Server: Unregistered {message}");
             _name = "";
+            _requests = null;
             _isRegistered = false;
             UpdateButton();
         }

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ConnectionView.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ConnectionView.kt
@@ -1,0 +1,127 @@
+package com.empowerops.volition.ref_oasis
+
+import com.google.common.eventbus.EventBus
+import com.google.common.eventbus.Subscribe
+import javafx.collections.FXCollections
+import javafx.collections.ObservableList
+import javafx.scene.layout.Priority
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.javafx.JavaFx
+import kotlinx.coroutines.launch
+import tornadofx.*
+
+class ConnectionView(
+        val dataModel: DataModelService,
+        val control: OptimizerEndpoint,
+        val eventBus: EventBus) : View("My View") {
+
+
+    private val regList: ObservableList<String> = FXCollections.observableArrayList()
+
+    override val root = listview<String> {
+        vgrow = Priority.ALWAYS
+        //TODO make this good looking item
+        isEditable = false
+        cellFormat {name ->
+            val node = dataModel.simulations.getValue(name)
+            graphic = vbox {
+                hbox {
+                    label("Name: ")
+                    label(name)
+                }
+                hbox {
+                    label("Description: ")
+                    textflow {
+                        text(node.description)
+                    }
+                }
+                hbox {
+                    label("Inputs: ")
+                    vbox {
+                        node.inputs.forEach { input ->
+                            add(label("${input.name} [${input.lowerBound}, ${input.upperBound}] "))
+                        }
+                    }
+                }
+                hbox {
+                    label("Outputs: ")
+                    vbox {
+                        node.outputs.forEach { output ->
+                            add(label(output.name))
+                        }
+                    }
+                }
+                hbox {
+                    spacing = 5.0
+                    button("refresh") {
+                        action {
+                            GlobalScope.launch {
+                                control.updateNode(name)
+                                dataModel.syncConfiguration(name)
+                            }
+                        }
+                    }
+                    button("delete") {
+                        action {
+                            GlobalScope.launch {
+                                dataModel.closeSim(name)
+                            }
+                        }
+                    }
+                    button("add setup") {
+                        action {
+                            GlobalScope.launch {
+                                dataModel.addConfiguration(name)
+                                dataModel.syncConfiguration(name)
+                            }
+                        }
+                    }
+                    button("remove setup") {
+                        action {
+                            GlobalScope.launch {
+                                dataModel.removeConfiguration(name)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    init {
+        eventBus.register(this)
+        root.items = regList
+    }
+
+    @Subscribe
+    fun whenNewNodeRegistered(event : PluginRegisteredEvent){
+        GlobalScope.launch(Dispatchers.JavaFx) {
+            regList.add(event.name)
+        }
+    }
+
+    @Subscribe
+    fun whenNodeUnRegistered(event : PluginUnRegisteredEvent){
+        GlobalScope.launch(Dispatchers.JavaFx) {
+            regList.remove(event.name)
+        }
+    }
+
+    @Subscribe
+    fun whenNodeUnRegistered(event : PluginRenamedEvent){
+        GlobalScope.launch(Dispatchers.JavaFx) {
+            regList.remove(event.oldName)
+            regList.add(event.newName)
+        }
+    }
+
+    @Subscribe
+    fun whenNodeRefreshed(event: PluginUpdatedEvent) {
+        GlobalScope.launch(Dispatchers.JavaFx) {
+            root.refresh()
+        }
+    }
+
+}
+

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/DataModelService.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/DataModelService.kt
@@ -1,92 +1,155 @@
 package com.empowerops.volition.ref_oasis
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.javafx.JavaFx
-import kotlinx.coroutines.launch
+import com.google.common.eventbus.EventBus
 import java.time.Duration
 
-class DataModelService(
-        val viewData: ViewData,
-        private val updateCallback: () -> Unit
-) : ModelService {
-    override var simByName: Map<String, Simulation> = emptyMap()
+interface Event
+interface ModelEvent : Event
 
-    override fun updateStatusMessage(message: String) {
-        GlobalScope.launch(Dispatchers.JavaFx) {
-            viewData.currentEvaluationStatus.value = message
+data class StatusUpdateEvent(val status: String) : Event
+data class NewMessageEvent(val message: Message) : Event
+data class NewResultEvent(val result: Result) : Event
+
+data class PluginRegisteredEvent(val name: String) : ModelEvent
+data class PluginUnRegisteredEvent(val name: String) : ModelEvent
+class PluginUpdatedEvent : ModelEvent
+data class PluginRenamedEvent(val oldName: String, val newName: String) : ModelEvent
+data class ProxyAddedEvent(val name: String) : ModelEvent
+data class ProxyRemovedEvent(val name: String) : ModelEvent
+data class ProxyRenamedEvent(val oldName: String, val newName: String) : ModelEvent
+class ProxyUpdatedEvent : ModelEvent
+
+fun <T : Nameable> List<T>.getValue(name: String) : T = single { it.name == name }
+fun <T : Nameable> List<T>.getNamed(name: String?) : T? = singleOrNull { it.name == name }
+fun <T : Nameable> List<T>.hasName(name: String?): Boolean = any { it.name == name }
+fun <T : Nameable> List<T>.replace(old: T, new: T) : List<T> = this - old + new
+fun <T : Nameable> List<T>.getNames(): List<String> = map{it.name}
+
+class DataModelService(private val eventBus: EventBus) {
+    var simulations: List<Simulation> = emptyList()
+    var proxies: List<Proxy> = emptyList()
+
+    fun setDuration(nodeName: String?, timeOut: Duration?) : Boolean{
+        val oldNode = proxies.getNamed(nodeName) ?: return false
+        proxies = proxies.replace(oldNode, oldNode.copy(timeOut = timeOut))
+        return true
+    }
+
+    fun renameSim(newName: String, oldName: String): Boolean {
+        val oldSim = simulations.getNamed(oldName) ?: return false
+        if (simulations.hasName(newName)) return false
+        simulations = simulations.replace (oldSim, oldSim.copy(name = newName))
+        eventBus.post(PluginRenamedEvent(oldName, newName))
+        renameProxy(newName, oldName)//this action may or may not be true and we don't care
+        return true
+    }
+
+    private fun renameProxy(newName: String, oldName: String): Boolean {
+        val oldProxy = proxies.getNamed(oldName) ?: return false
+        if (proxies.hasName(newName)) return false
+        proxies = proxies.replace(oldProxy, oldProxy.copy(name = newName))
+        eventBus.post(ProxyRenamedEvent(oldName, newName))
+        return true
+    }
+
+    fun addNewSim(simulation: Simulation) : Boolean {
+        if (simulations.hasName(simulation.name)) return false
+
+        simulations += simulation
+        eventBus.post(PluginRegisteredEvent(simulation.name))
+        return true
+    }
+
+    /**
+     * try unregister a node and remove it
+     */
+    fun closeSim(name: String) : Boolean{
+        val sim = simulations.getNamed(name) ?: return false
+        try {
+            sim.input.onCompleted()
+        } finally {
+            return removeSim(name)
         }
     }
 
-    override fun addMessage(message: Message) {
-        GlobalScope.launch(Dispatchers.JavaFx) {
-            viewData.allMessages.add(message)
+    private fun removeSim(name: String) : Boolean {
+        val sim = simulations.getNamed(name) ?: return false
+        simulations -= sim
+        eventBus.post(PluginUnRegisteredEvent(name))
+        return true
+    }
+
+    fun updateSim(newSim: Simulation) : Boolean{
+        val oldSim = simulations.getNamed(newSim.name) ?: return false
+        simulations = simulations.replace(oldSim, newSim)
+        eventBus.post(PluginUpdatedEvent())
+        return true
+    }
+
+    fun addConfiguration(name: String) : Boolean {
+        if (proxies.hasName(name)) return false
+        proxies += Proxy(name)
+        eventBus.post(ProxyAddedEvent(name))
+        return true
+    }
+
+    /**
+     * Match the setup between proxy and its simulation
+     */
+    fun syncConfiguration(name: String) : Boolean{
+        val oldProxy = proxies.getNamed(name) ?: return false
+        val sim = simulations.getNamed(name) ?: return false
+        proxies = proxies.replace(oldProxy, Proxy(name, sim.inputs, sim.outputs, oldProxy.timeOut))
+        eventBus.post(ProxyUpdatedEvent())
+        return true
+    }
+
+    /**
+     * Match the setup between proxy and its simulation
+     */
+    fun syncConfiguration(newProxy: Proxy) : Boolean{
+        val oldProxy = proxies.getNamed(newProxy.name) ?: return false
+        proxies = proxies.replace(oldProxy, newProxy)
+        eventBus.post(ProxyUpdatedEvent())
+        return true
+    }
+
+    fun removeConfiguration(name: String) : Boolean{
+        val proxy = proxies.getNamed(name) ?: return false
+        proxies -= proxy
+        eventBus.post(ProxyRemovedEvent(name))
+        return true
+    }
+
+
+    fun findIssue(): List<String> {
+        var issues = emptyList<String>()
+        val proxyNames = proxies.getNames()
+        val simNames = simulations.getNames()
+
+        val proxyWithNoMatchingSim = proxyNames - simNames
+        if (proxyWithNoMatchingSim.isNotEmpty()) {
+            proxyWithNoMatchingSim.forEach {
+                issues += "Proxy Missing Simulation: Proxy setup \"$it\" reference to a missing simulation"
+            }
         }
-    }
 
-    override fun addResult(result: Result) {
-        GlobalScope.launch(Dispatchers.JavaFx) {
-            viewData.resultList.add(result)
+        val simWithNoMatchingProxy = simNames - proxyNames
+        if (simWithNoMatchingProxy.isNotEmpty()) {
+            simWithNoMatchingProxy.forEach {
+                issues += "Not used Simulation: Simulation \"$it\" are not used in any proxy setup"
+            }
         }
-    }
 
-    override fun setDuration(nodeName: String?, timeOut: Duration?) {
-        if (nodeName == null || !simByName.containsKey(nodeName)) {
-            return
+        proxies.forEach { proxy ->
+            val name = proxy.name
+            val simulation = simulations.getNamed(name)
+            if (simulation != null) {
+                if (proxy.inputs.map { it.name } != simulation.inputs.map { it.name } || proxy.outputs != simulation.outputs) {
+                    issues += "Sync issue: Proxy setup \"$name\" is out of sync with simluaiton \"$name\""
+                }
+            }
         }
-        val node: Simulation = simByName.getValue(nodeName)
-        val newNode = node.copy(timeOut = timeOut)
-        simByName += nodeName to newNode
+        return issues
     }
-
-    override fun renameSim(target: Simulation, newName: String, oldName: String) {
-        require(simByName.containsKey(oldName) && !simByName.containsKey(newName))
-        simByName += newName to target
-        simByName -= oldName
-        removeNodeFromView(oldName)
-        addNodeToView(newName)
-    }
-
-    override fun removeSim(name: String) {
-        require(simByName.containsKey(name))
-        simByName -= name
-        removeNodeFromView(name)
-    }
-
-    override fun addNewSim(simulation: Simulation) {
-        require( ! simByName.containsKey(simulation.name))
-        simByName += simulation.name to simulation
-        addNodeToView(simulation.name)
-    }
-
-    override fun updateSim(newNode: Simulation) {
-        require(simByName.containsKey(newNode.name))
-        simByName += newNode.name to newNode
-        rebindView()
-    }
-
-    private fun addNodeToView(name: String) {
-        GlobalScope.launch(Dispatchers.JavaFx) {
-            viewData.nodes.add(name)
-        }
-    }
-
-    private fun removeNodeFromView(name: String) {
-        GlobalScope.launch(Dispatchers.JavaFx) {
-            viewData.nodes.remove(name)
-        }
-    }
-
-    private fun removeAllNodesFromView() {
-        GlobalScope.launch(Dispatchers.JavaFx) {
-            viewData.nodes.clear()
-        }
-    }
-
-    private fun rebindView() {
-        GlobalScope.launch(Dispatchers.JavaFx) {
-            updateCallback.invoke()
-        }
-    }
-
 }

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Models.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Models.kt
@@ -5,22 +5,10 @@ import com.empowerops.volition.dto.NodeStatusCommandOrResponseDTO
 import com.empowerops.volition.dto.OASISQueryDTO
 import com.empowerops.volition.dto.SimulationResponseDTO
 import io.grpc.stub.StreamObserver
+import javafx.collections.ObservableMap
 import kotlinx.coroutines.channels.Channel
 import java.time.Duration
 import java.time.LocalDateTime
-
-interface ModelService {
-    var simByName: Map<String, Simulation>
-    fun updateStatusMessage(message: String)
-    fun addMessage(message: Message)
-    fun addResult(result: Result)
-    fun setDuration(nodeName: String?, timeOut: Duration?)
-
-    fun updateSim(newNode: Simulation)
-    fun addNewSim(simulation: Simulation)
-    fun removeSim(name: String)
-    fun renameSim(target: Simulation, newName: String, oldName: String)
-}
 
 data class Input(
         val name: String,
@@ -46,14 +34,24 @@ data class Result(
         val outputs: String
 )
 
+interface Nameable{
+    val name: String
+}
+
 data class Simulation(
-        val name: String,
+        override val name: String,
         val inputs: List<Input>,
         val outputs: List<Output>,
         val description: String,
         val input: StreamObserver<OASISQueryDTO>,
         val output: Channel<SimulationResponseDTO>,
         val update: Channel<NodeStatusCommandOrResponseDTO>,
-        val error: Channel<ErrorResponseDTO>,
+        val error: Channel<ErrorResponseDTO>
+) : Nameable
+
+data class Proxy(
+        override val name : String,
+        val inputs: List<Input> = emptyList(),
+        val outputs: List<Output> = emptyList(),
         val timeOut: Duration? = null
-)
+) : Nameable

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerController.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerController.kt
@@ -1,210 +1,298 @@
 package com.empowerops.volition.ref_oasis
 
+import com.google.common.eventbus.EventBus
+import com.google.common.eventbus.Subscribe
 import com.sun.javafx.binding.StringConstant
+import javafx.beans.property.Property
 import javafx.beans.property.SimpleStringProperty
+import javafx.collections.FXCollections
 import javafx.collections.ObservableList
 import javafx.fxml.FXML
 import javafx.scene.control.*
+import javafx.scene.control.cell.TextFieldTreeTableCell
 import javafx.scene.control.cell.TreeItemPropertyValueFactory
 import javafx.scene.input.KeyCode
 import javafx.scene.layout.AnchorPane
 import javafx.scene.layout.VBox
+import javafx.util.converter.DoubleStringConverter
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.javafx.JavaFx
 import kotlinx.coroutines.launch
-import tornadofx.selectedItem
+import tornadofx.*
 import java.time.Duration
 
-data class ViewData(
-        val nodes: ObservableList<String>,
-        val allMessages: ObservableList<Message>,
-        val currentEvaluationStatus: SimpleStringProperty,
-        val resultList: ObservableList<Result>,
-        val updateList : ObservableList<String>){
-}
-
 class OptimizerController {
-    @FXML lateinit var view : AnchorPane
-    @FXML lateinit var nodesList : ListView<String>
-    @FXML lateinit var messageTableView : TableView<Message>
-    @FXML lateinit var resultTableView : TableView<Result>
 
-    @FXML lateinit var messageSenderColumn : TableColumn<Message, String>
-    @FXML lateinit var timeColumn : TableColumn<Message, String>
-    @FXML lateinit var messageColumn : TableColumn<Message, String>
+    /**
+     * This is backing view object for the tree table view, Not intended to use for any data model
+     */
+    internal class Parameter(
+            val name: String,
+            val type: OptimizerController.Type,
+            val value: Double? = null
+    ) {
+        var upperBound: Double? by property()
+        fun upperBoundProperty(): Property<Double?> = getProperty(Parameter::upperBound)
 
-    @FXML lateinit var resultSenderColumn : TableColumn<Result, String>
-    @FXML lateinit var typeColumn : TableColumn<Result, String>
-    @FXML lateinit var inputColumn  : TableColumn<Result, String>
-    @FXML lateinit var outputColumn : TableColumn<Result, String>
+        var lowerBound: Double? by property()
+        fun lowerBoundProperty(): Property<Double?> = getProperty(Parameter::lowerBound)
+    }
 
-    @FXML lateinit var paramTreeView : TreeTableView<Parameter>
-    @FXML lateinit var nameColumn : TreeTableColumn<Parameter, String>
-    @FXML lateinit var valueColumn : TreeTableColumn<Parameter, String>
-    @FXML lateinit var lbColumn : TreeTableColumn<Parameter, String>
-    @FXML lateinit var upColumn : TreeTableColumn<Parameter, String>
+    @FXML lateinit var view: AnchorPane
+    @FXML lateinit var nodesList: ListView<String>
+    @FXML lateinit var messageTableView: TableView<Message>
+    @FXML lateinit var resultTableView: TableView<Result>
+    @FXML lateinit var messageSenderColumn: TableColumn<Message, String>
+    @FXML lateinit var timeColumn: TableColumn<Message, String>
+    @FXML lateinit var messageColumn: TableColumn<Message, String>
+    @FXML lateinit var resultSenderColumn: TableColumn<Result, String>
+    @FXML lateinit var typeColumn: TableColumn<Result, String>
+    @FXML lateinit var inputColumn: TableColumn<Result, String>
+    @FXML lateinit var outputColumn: TableColumn<Result, String>
+    @FXML internal lateinit var paramTreeView: TreeTableView<Parameter>
+    @FXML internal lateinit var nameColumn: TreeTableColumn<Parameter, String>
+    @FXML internal lateinit var valueColumn: TreeTableColumn<Parameter, String>
+    @FXML internal lateinit var lbColumn: TreeTableColumn<Parameter, Double>
+    @FXML internal lateinit var upColumn: TreeTableColumn<Parameter, Double>
+    @FXML lateinit var optimizerStatusLabel: Label
+    @FXML lateinit var descriptionLabel: Label
+    @FXML lateinit var selectedNodeInfoBox: VBox
+    @FXML lateinit var timeOutTextField: TextField
+    @FXML lateinit var useTimeout: CheckBox
+    @FXML lateinit var connectionListContainer: VBox
+    @FXML lateinit var issuesTextArea: TextArea
+    @FXML lateinit var pauseButton: Button
 
+    private val list: ObservableList<String> = FXCollections.observableArrayList()
+    private val messageList: ObservableList<Message> = FXCollections.observableArrayList()
+    private val resultList: ObservableList<Result> = FXCollections.observableArrayList()
+    private val currentEvaluationStatus = SimpleStringProperty()
+    private val issuesText = SimpleStringProperty()
 
-    @FXML lateinit var statusLabel : Label
-    @FXML lateinit var optimizerStatusLabel : Label
-    @FXML lateinit var descriptionLabel : Label
-    @FXML lateinit var selectedNodeInfoBox : VBox
-    @FXML lateinit var timeOutTextField : TextField
-    @FXML lateinit var useTimeout : CheckBox
-
-    lateinit var control : OptimizerEndpoint
-    lateinit var modelService : ModelService
+    private lateinit var endpoint: OptimizerEndpoint
+    private lateinit var modelService: DataModelService
+    private lateinit var inputRoot: TreeItem<Parameter>
+    private lateinit var outputRoot: TreeItem<Parameter>
 
     enum class Type {
         Input, Output, Root
     }
 
-    data class Parameter(
-            val name: String,
-            val type: Type,
-            val value : Double? = null,
-            val lowerBound: Double? = null,
-            val upperBound: Double? = null
-    )
-
-    fun buildTree(config: Simulation): TreeItem<Parameter> {
+    private fun buildTree(config: Proxy?): TreeItem<Parameter> {
         val root = TreeItem<Parameter>(Parameter("root", Type.Root))
-        val root1 = TreeItem<Parameter>(Parameter("Inputs", Type.Root))
-        val root2 = TreeItem<Parameter>(Parameter("Outputs", Type.Root))
+        inputRoot = TreeItem(Parameter("Inputs", Type.Root))
+        outputRoot = TreeItem(Parameter("Outputs", Type.Root))
+        if(config==null) return root
 
         val inputs: List<TreeItem<Parameter>> = config.inputs.map {
-            TreeItem(Parameter(it.name, Type.Input, it.currentValue, it.lowerBound, it.upperBound))
+            val value = Parameter(it.name, Type.Input, it.currentValue)
+            value.lowerBound = it.lowerBound
+            value.upperBound = it.upperBound
+            TreeItem(value)
         }
         val outputs: List<TreeItem<Parameter>> = config.outputs.map {
             TreeItem(Parameter(it.name, Type.Input))
         }
 
-        root1.isExpanded = true
-        root2.isExpanded = true
+        inputRoot.isExpanded = true
+        outputRoot.isExpanded = true
 
-        root1.children.addAll(inputs)
-        root2.children.addAll(outputs)
+        inputRoot.children.addAll(inputs)
+        outputRoot.children.addAll(outputs)
 
-        root.children.addAll(root1, root2)
+        root.children.addAll(inputRoot, outputRoot)
         return root
     }
 
     @FXML fun initialize() {
-        messageSenderColumn.setCellValueFactory { dataFeatures ->  StringConstant.valueOf(dataFeatures.value.sender) }
-        timeColumn.setCellValueFactory { dataFeatures ->  StringConstant.valueOf(dataFeatures.value.receiveTime.toString()) }
-        messageColumn.setCellValueFactory { dataFeatures ->  StringConstant.valueOf(dataFeatures.value.message) }
+        nodesList.items = list
+        messageTableView.items = messageList
+        resultTableView.items = resultList
+        optimizerStatusLabel.textProperty().bind(currentEvaluationStatus)
+        issuesTextArea.textProperty().bind(issuesText)
 
-        resultSenderColumn.setCellValueFactory { dataFeatures ->  StringConstant.valueOf(dataFeatures.value.name) }
-        typeColumn.setCellValueFactory { dataFeatures ->  StringConstant.valueOf(dataFeatures.value.resultType) }
-        inputColumn.setCellValueFactory { dataFeatures ->  StringConstant.valueOf(dataFeatures.value.inputs) }
-        outputColumn.setCellValueFactory { dataFeatures ->  StringConstant.valueOf(dataFeatures.value.outputs) }
-
-        nameColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, String>("name")
-        valueColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, String>("value")
-        lbColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, String>("lowerBound")
-        upColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, String>("upperBound")
+        setupMessageTable()
+        setupResultTable()
+        setupParameterTableTree()
 
         nodesList.selectionModel.selectedItemProperty().addListener { src, oldV, newV -> showNode(newV) }
 
-        timeOutTextField.setOnKeyPressed{ event ->
-            if(event.code == KeyCode.ESCAPE){
+        timeOutTextField.setOnKeyPressed { event ->
+            if (event.code == KeyCode.ESCAPE) {
                 //discard
-                timeOutTextField.text = modelService.simByName.getValue(nodesList.selectedItem!!).timeOut!!.toMillis().toString()
+                timeOutTextField.text = modelService.proxies.single { it.name == nodesList.selectedItem!! }.timeOut!!.toMillis().toString()
                 view.requestFocus()
-            }
-            else if (event.code == KeyCode.ENTER) {
+            } else if (event.code == KeyCode.ENTER) {
                 //commit
                 val duration = timeOutTextField.text.toLongOrNull()
-                if(duration == null){
+                if (duration == null) {
                     timeOutTextField.text = ""
-                }
-                else{
+                } else {
                     modelService.setDuration(nodesList.selectedItem, Duration.ofMillis(duration))
                 }
                 view.requestFocus()
             }
         }
 
-        useTimeout.selectedProperty().addListener{s, oldV, newV ->
-            if(newV){
+        useTimeout.selectedProperty().addListener { s, oldV, newV ->
+            if (newV) {
                 modelService.setDuration(nodesList.selectedItem, Duration.ZERO)
                 timeOutTextField.text = "0"
-            }
-            else{
+            } else {
                 modelService.setDuration(nodesList.selectedItem, null)
                 timeOutTextField.text = ""
             }
         }
 
         timeOutTextField.disableProperty().bind(useTimeout.selectedProperty().not())
+
+
+    }
+
+    private fun setupMessageTable() {
+        messageSenderColumn.setCellValueFactory { dataFeatures -> StringConstant.valueOf(dataFeatures.value.sender) }
+        timeColumn.setCellValueFactory { dataFeatures -> StringConstant.valueOf(dataFeatures.value.receiveTime.toString()) }
+        messageColumn.setCellValueFactory { dataFeatures -> StringConstant.valueOf(dataFeatures.value.message) }
+    }
+
+    private fun setupResultTable() {
+        resultSenderColumn.setCellValueFactory { dataFeatures -> StringConstant.valueOf(dataFeatures.value.name) }
+        typeColumn.setCellValueFactory { dataFeatures -> StringConstant.valueOf(dataFeatures.value.resultType) }
+        inputColumn.setCellValueFactory { dataFeatures -> StringConstant.valueOf(dataFeatures.value.inputs) }
+        outputColumn.setCellValueFactory { dataFeatures -> StringConstant.valueOf(dataFeatures.value.outputs) }
+    }
+
+    private fun setupParameterTableTree() {
+        nameColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, String>("name")
+        valueColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, String>("value")
+        lbColumn.cellFactory = TextFieldTreeTableCell.forTreeTableColumn(DoubleStringConverter())
+        lbColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, Double>("lowerBound")
+        upColumn.cellFactory = TextFieldTreeTableCell.forTreeTableColumn(DoubleStringConverter())
+        upColumn.cellValueFactory = TreeItemPropertyValueFactory<Parameter, Double>("upperBound")
+        lbColumn.setOnEditCommit {
+            it.rowValue.value!!.lowerBound = it.newValue
+            generateAndUpdateNewProxy()
+        }
+        upColumn.setOnEditCommit {
+            it.rowValue.value!!.upperBound = it.newValue
+            generateAndUpdateNewProxy()
+        }
+    }
+
+    private fun generateAndUpdateNewProxy() : Boolean{
+        val selectedItem = nodesList.selectionModel.selectedItem
+        if (selectedItem == null) {
+            return false
+        } else {
+            val proxy = modelService.proxies.single { it.name == selectedItem }
+            val rebuildInputList: List<Input> = inputRoot.children.map {
+                val parameter = it.value
+                Input(parameter.name, parameter.lowerBound ?: Double.NaN, parameter.upperBound ?: Double.NaN, 0.0)
+            }
+            val newProxy = proxy.copy(inputs = rebuildInputList)
+            modelService.syncConfiguration(newProxy)
+            return true
+        }
     }
 
     private fun showNode(newV: String?) {
-        if(newV == null){
-            selectedNodeInfoBox.isDisable = true
-        }
-        else{
-            selectedNodeInfoBox.isDisable = false
-            val sim = modelService.simByName.getValue(newV)
-            descriptionLabel.text = newV
-            val buildTree = buildTree(sim)
-            paramTreeView.root = buildTree
-            paramTreeView.isShowRoot = false
-            statusLabel.text = sim.description
-            if(sim.timeOut!= null){
-                useTimeout.isSelected = true
-                timeOutTextField.text = sim.timeOut.toMillis().toString()
-            }
-            else{
-                useTimeout.isSelected = false
-                timeOutTextField.text = ""
-            }
+        selectedNodeInfoBox.isDisable = newV == null
+        displayConfiguration(modelService.proxies.singleOrNull{it.name == newV})
+    }
+
+    private fun displayConfiguration(proxy: Proxy?) {
+        descriptionLabel.text = proxy?.name
+        paramTreeView.root = buildTree(proxy)
+        paramTreeView.isShowRoot = false
+        if (proxy?.timeOut != null) {
+            useTimeout.isSelected = true
+            timeOutTextField.text = proxy.timeOut.toMillis().toString()
+        } else {
+            useTimeout.isSelected = false
+            timeOutTextField.text = ""
         }
     }
 
-    fun setData(dataModelService: DataModelService, control: OptimizerEndpoint){
-        nodesList.items = dataModelService.viewData.nodes
-        messageTableView.items = dataModelService.viewData.allMessages
-        resultTableView.items = dataModelService.viewData.resultList
+    fun setData(dataModelService: DataModelService, endpoint: OptimizerEndpoint, eventBus: EventBus, connectionView: ListView<String>) {
+        eventBus.register(this)
         modelService = dataModelService
-        optimizerStatusLabel.textProperty().bind(dataModelService.viewData.currentEvaluationStatus)
-        this.control = control
+        connectionListContainer.children.add(connectionView)
+        this.endpoint = endpoint
+        showNode(null)
     }
 
-    @FXML fun startRun() = GlobalScope.launch{
-        control.startOptimization(RandomNumberOptimizer())
+    @FXML
+    fun startRun() = GlobalScope.launch {
+        endpoint.startOptimization(RandomNumberOptimizer())
     }
 
-    @FXML fun stopRun()= GlobalScope.launch{
-        control.stopOptimization()
+    @FXML
+    fun stopRun() = GlobalScope.launch(Dispatchers.JavaFx) {
+        endpoint.stopOptimization()
+        pauseButton.text = "Pause"
     }
 
-    @FXML fun cancelRun()= GlobalScope.launch{
+    @FXML
+    fun pauseRun() = GlobalScope.launch(Dispatchers.JavaFx) {
+        val paused = endpoint.pauseOptimization()
+        pauseButton.text = if (paused) "Resume" else "Pause"
+    }
+
+    @FXML
+    fun cancelAll() = GlobalScope.launch {
+        endpoint.cancelAll()
+    }
+
+    @FXML
+    fun cancelAndStop() = GlobalScope.launch {
+        endpoint.cancelAndStop()
+    }
+
+    @FXML
+    fun removeSelectedSetup() = GlobalScope.launch {
         val selectedItem = nodesList.selectedItem
-        if(selectedItem != null){
-            control.cancel(selectedItem)
-        }
+        if (selectedItem != null) modelService.removeConfiguration(selectedItem)
     }
 
-    @FXML fun cancelAll() = GlobalScope.launch{
-        control.cancelAll()
+    @Subscribe fun onNewResult(event: NewResultEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        resultList.add(event.result)
     }
 
-    @FXML fun cancelAndStop()= GlobalScope.launch{
-        control.cancelAndStop()
+    @Subscribe fun onStateChange(event: StatusUpdateEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        currentEvaluationStatus.value = event.status
     }
 
-    @FXML fun syncAll()= GlobalScope.launch{
-        control.syncAll()
+    @Subscribe fun onNewMessage(event: NewMessageEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        messageList.add(event.message)
     }
 
-    @FXML fun refresh()= GlobalScope.launch{
-        val selectedItem = nodesList.selectedItem
-        if(selectedItem != null){
-            control.updateNode(selectedItem)
-        }
+    @Subscribe fun whenProxyAdded(event: ProxyAddedEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        list.add(event.name)
     }
 
-    fun rebindView() {
+    @Subscribe fun whenProxyRemoved(event: ProxyRemovedEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        list.remove(event.name)
+    }
+
+    @Subscribe fun whenProxyRenamed(event: ProxyRenamedEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        list.remove(event.oldName)
+        list.add(event.newName)
+    }
+
+    @Subscribe fun whenProxyUpdated(event: ProxyUpdatedEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        nodesList.refresh()
+        showNode(null)
         showNode(nodesList.selectedItem)
     }
+
+    @Subscribe fun whenIssueUpdated(event: ModelEvent) = GlobalScope.launch(Dispatchers.JavaFx) {
+        val issueList = modelService.findIssue()
+        if (issueList.isNotEmpty()) {
+            issuesText.set(issueList.joinToString("\n"))
+        } else {
+            issuesText.set(null)
+        }
+    }
+
 }

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerEndPoint.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerEndPoint.kt
@@ -1,210 +1,228 @@
 package com.empowerops.volition.ref_oasis
 
 import com.empowerops.volition.dto.*
+import com.google.common.eventbus.EventBus
 import io.grpc.stub.StreamObserver
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.selects.select
 import org.funktionale.either.Either
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
 import java.time.Duration
 
-sealed class SimResult {
-    data class Success(val name: String, val result: Map<String, Double>) : SimResult()
-    data class TimeOut(val name: String) : SimResult()
-    data class TimeOutFailure(val name: String, val exception: String) : SimResult()
-    data class Failure(val name: String, val exception: String) : SimResult()
+sealed class EvaluationResult {
+    data class Success(val name: String, val result: Map<String, Double>) : EvaluationResult()
+    data class TimeOut(val name: String) : EvaluationResult()
+    data class Failed(val name: String, val exception: String) : EvaluationResult()
+    data class Error(val name: String, val exception: String) : EvaluationResult()
+}
+
+sealed class CancelResult {
+    data class Canceled(val name: String) : CancelResult()
+    data class CancelFailed(val name: String, val exception: String) : CancelResult()
 }
 
 class OptimizerEndpoint(
-        private val modelService: ModelService
+        private val modelService: DataModelService,
+        private val eventBus: EventBus
 ) : OptimizerGrpc.OptimizerImplBase() {
-    var state = State.Idle
+    private var state = State.Idle
 
     enum class State {
         Idle,
-        Running
+        Running,
+        Pause
     }
 
     override fun changeNodeName(request: NodeNameChangeCommandDTO, responseObserver: StreamObserver<NodeNameChangeResponseDTO>) = responseObserver.consume {
-        val newName = request.newName
-        val newNameSimulation = modelService.simByName[newName]
-        val oldName = request.oldName
-        val target = modelService.simByName[oldName]
-        val changed = if (newNameSimulation == null && target != null) {
-            modelService.renameSim(target, newName, oldName)
-            true
-        } else {
-            false
-        }
-
+        val changed = modelService.renameSim(request.newName, request.oldName)
         NodeNameChangeResponseDTO.newBuilder().setChanged(changed).build()
     }
 
     override fun register(request: RegistrationCommandDTO, responseObserver: StreamObserver<OASISQueryDTO>) {
-        if (request.name in modelService.simByName.keys) {
+        if (modelService.simulations.hasName(request.name)) {
+            responseObserver.onCompleted()
             return
         }
         modelService.addNewSim(Simulation(request.name, emptyList(), emptyList(), "", responseObserver, Channel(RENDEZVOUS), Channel(RENDEZVOUS), Channel(RENDEZVOUS)))
-        modelService.updateStatusMessage("${request.name} registered")
-    }
-
-    fun unregisterAll() {
-        throw NotImplementedException()
+        eventBus.post(StatusUpdateEvent("${request.name} registered"))
     }
 
     override fun startOptimization(request: StartOptimizationCommandDTO, responseObserver: StreamObserver<StartOptimizationResponseDTO>) = responseObserver.consume {
-        GlobalScope.async { startOptimization(RandomNumberOptimizer()) }
-        StartOptimizationResponseDTO.newBuilder().setMessage("Started").setStarted(true).build()
-    }
+        val issues = modelService.findIssue()
+        val message: String
 
+        if (issues.isNotEmpty()) {
+            message = "Optimization cannot start: ${issues.joinToString(", ")}"
+        } else {
+            message = "Optimization started"
+            GlobalScope.async { startOptimization(RandomNumberOptimizer()) }
+        }
+
+        StartOptimizationResponseDTO.newBuilder().setMessage(message).setStarted(issues.isEmpty()).build()
+    }
 
     suspend fun startOptimization(optimizer: RandomNumberOptimizer) {
         state = State.Running
-
-        for (simName in modelService.simByName.keys) {
-            syncConfigFor(simName)
-        }
-
-        modelService.updateStatusMessage("Evaluating...")
-
+        eventBus.post(StatusUpdateEvent("Evaluating..."))
         while (state == State.Running) {
-            var toolNumber = 1
-            for ((simName, sim) in modelService.simByName) {
-                modelService.updateStatusMessage("Evaluating: $simName ($toolNumber/${modelService.simByName.keys.size})")
-                val inputVector = optimizer.generateInputs(sim.inputs)
-                val message = OASISQueryDTO.newBuilder()
-                        .setEvaluationRequest(OASISQueryDTO.SimulationEvaluationRequest.newBuilder()
-                                .setName(simName)
-                                .putAllInputVector(inputVector)
-                        )
-                        .build()
-
-                sim.input.onNext(message)
-                val result = select<SimResult> {
-                    sim.output.onReceive { SimResult.Success(it.name, it.outputVectorMap) }
-                    sim.error.onReceive { SimResult.Failure(it.name, it.exception) }
-                    if (sim.timeOut != null) {
-                        onTimeout(sim.timeOut.toMillis()) {
-                            //Timed out
-                            val message = OASISQueryDTO.newBuilder().setCancelRequest(
-                                    OASISQueryDTO.SimulationCancelRequest.newBuilder().setName(simName)
-                            ).build()
-                            sim.input.onNext(message)
-                            select {
-                                sim.output.onReceive { SimResult.TimeOut(it.name) }
-                                sim.error.onReceive { SimResult.TimeOutFailure(it.name, it.exception) }
-                            }
-                        }
-                    }
+            var pluginNumber = 1
+            for (proxy in modelService.proxies) {
+                eventBus.post(StatusUpdateEvent("Evaluating: ${proxy.name} ($pluginNumber/${modelService.simulations.size})"))
+                val inputVector = optimizer.generateInputs(proxy.inputs)
+                val simResult = evaluate(proxy.name, inputVector)
+                eventBus.post(NewResultEvent(makeResult(simResult, inputVector)))
+                eventBus.post(StatusUpdateEvent("Evaluation finished."))
+                if (simResult is EvaluationResult.TimeOut) {
+                    eventBus.post(StatusUpdateEvent("Timed out, Canceling..."))
+                    cancel(proxy.name)
+                    eventBus.post(StatusUpdateEvent("Cancel finished."))
                 }
-
-                val resultMessage = when (result) {
-                    is SimResult.Success -> {
-                        Result(result.name, "Success", inputVector.toString(), result.result.toString())
-                    }
-                    is SimResult.Failure -> {
-                        Result(result.name, "Error", inputVector.toString(), "Failure: \n${result.exception}")
-                    }
-                    is SimResult.TimeOut -> {
-                        Result(result.name, "Canceled", inputVector.toString(), "Timeout")
-                    }
-                    is SimResult.TimeOutFailure -> {
-                        Result(result.name, "Cancel Failed", inputVector.toString(), "Cancellation failed:\n${result.exception}")
-                    }
+                pluginNumber++
+            }
+            if (state == State.Pause) {
+                eventBus.post(StatusUpdateEvent("Paused"))
+                while (state == State.Pause && state != State.Idle) {
+                    delay(500)
                 }
-                modelService.addResult(resultMessage)
-                toolNumber++
             }
         }
-        modelService.updateStatusMessage("Idle")
-
+        eventBus.post(StatusUpdateEvent("Idle"))
     }
 
+    private fun makeResult(evaluationResult: EvaluationResult, inputVector: Map<String, Double>): Result = when (evaluationResult) {
+        is EvaluationResult.Success -> {
+            Result(evaluationResult.name, "Success", inputVector.toString(), evaluationResult.result.toString())
+        }
+        is EvaluationResult.Failed -> {
+            Result(evaluationResult.name, "Failed", inputVector.toString(), "Evaluation Failed: \n${evaluationResult.exception}")
+        }
+        is EvaluationResult.TimeOut -> {
+            Result(evaluationResult.name, "Timeout", inputVector.toString(), "N/A")
+        }
+        is EvaluationResult.Error -> {
+            Result(evaluationResult.name, "Error", inputVector.toString(), "Error:\n${evaluationResult.exception}")
+        }
+    }
 
-    suspend fun stopOptimization() : Boolean {
+    private suspend fun evaluate(name: String, inputVector: Map<String, Double>): EvaluationResult {
+        val simulation = modelService.simulations.getValue(name)
+        val proxy = modelService.proxies.getValue(name)
+        val message = OASISQueryDTO.newBuilder().setEvaluationRequest(
+                OASISQueryDTO.SimulationEvaluationRequest
+                        .newBuilder()
+                        .setName(name)
+                        .putAllInputVector(inputVector)
+        ).build()
+
+        return try {
+            simulation.input.onNext(message)
+            select {
+                simulation.output.onReceive { EvaluationResult.Success(it.name, it.outputVectorMap) }
+                simulation.error.onReceive { EvaluationResult.Failed(it.name, it.exception) }
+                if (proxy.timeOut != null) {
+                    onTimeout(proxy.timeOut.toMillis()) {
+                        EvaluationResult.TimeOut(name)
+                    }
+                }
+            }
+        } catch (exception: Exception) {
+            EvaluationResult.Error("Optimizer", "Unexpected error happened when try to evaluate $inputVector though simulation $name. Cause: $exception")
+        }
+    }
+
+    fun stopOptimization(): Boolean {
         state = State.Idle
         return true
     }
 
-    suspend fun syncAll() {
-        for (simName in modelService.simByName.keys) {
-            syncConfigFor(simName)
+    fun pauseOptimization(): Boolean = when (state) {
+        State.Running -> {
+            state = State.Pause
+            true
         }
+        State.Pause -> {
+            state = State.Running
+            false
+        }
+        else -> false
     }
 
     suspend fun updateNode(simName: String) {
         syncConfigFor(simName)
-
     }
 
     suspend fun cancelAll() {
-        for ((name, sim) in modelService.simByName) {
-            val message = OASISQueryDTO.newBuilder().setCancelRequest(
-                    OASISQueryDTO.SimulationCancelRequest.newBuilder().setName(name)
-            ).build()
+        modelService.simulations.forEach { cancel(it.name) }
+    }
 
-            sim.input.onNext(message)
+    /**
+     * Cancel is NOT running in async mode because we are not managing state for plugin and we always assume plugin is in ready state
+     * whenever it returns a result
+     */
+    private suspend fun cancel(name: String) {
+        val message = OASISQueryDTO.newBuilder().setCancelRequest(OASISQueryDTO.SimulationCancelRequest.newBuilder().setName(name)).build()
+        val simulation = modelService.simulations.getValue(name)
+
+        simulation.input.onNext(message)
+        val cancelResult = select<CancelResult> {
+            simulation.output.onReceive { CancelResult.Canceled(it.name) }
+            simulation.error.onReceive { CancelResult.CancelFailed(it.name, it.exception) }
         }
-    }
-
-    suspend fun cancel(name: String) {
-        val message = OASISQueryDTO.newBuilder().setCancelRequest(
-                OASISQueryDTO.SimulationCancelRequest.newBuilder().setName(name)
-        ).build()
-
-        modelService.simByName.getValue(name).input.onNext(message)
-    }
-
-    fun disconnectAll() {
-       throw NotImplementedException()
+        val cancelMessage = when (cancelResult) {
+            is CancelResult.Canceled -> {
+                Message("Optimizer", "Evaluation Canceled")
+            }
+            is CancelResult.CancelFailed -> {
+                Message("Optimizer", "Cancellation Failed, Cause:\n${cancelResult.exception}")
+            }
+        }
+        eventBus.post(NewMessageEvent(cancelMessage))
     }
 
     suspend fun cancelAndStop() {
         stopOptimization()
-        for ((name, sim) in modelService.simByName) {
-            val message = OASISQueryDTO.newBuilder().setCancelRequest(
-                    OASISQueryDTO.SimulationCancelRequest.newBuilder().setName(name)
-            ).build()
-            sim.input.onNext(message)
-        }
+        cancelAll()
     }
 
     private suspend fun syncConfigFor(simName: String) {
-        val sim = modelService.simByName.getValue(simName)
+        val sim = modelService.simulations.getValue(simName)
         val message = OASISQueryDTO.newBuilder().setNodeStatusRequest(
                 OASISQueryDTO.NodeStatusUpdateRequest.newBuilder().setName(simName)
         ).build()
+        var result: Either<Simulation, Message>
+        try {
+            sim.input.onNext(message)
 
-        sim.input.onNext(message)
-
-        val result = select<Either<Simulation, Message>> {
-            sim.update.onReceive { Either.Left(updateFromResponse(it)) }
-            sim.error.onReceive {
-                Either.Right(Message(it.name, "Error update simulation $simName due to ${it.message} :\n${it.exception}"))
+            result = select {
+                sim.update.onReceive { Either.Left(updateFromResponse(it)) }
+                sim.error.onReceive {
+                    Either.Right(Message(it.name, "Error update simulation $simName due to ${it.message} :\n${it.exception}"))
+                }
+                onTimeout(Duration.ofSeconds(5).toMillis()) {
+                    Either.Right(Message("Optimizer", "Update simulation timeout. Please check simulation is registered and responsive."))
+                }
             }
-            onTimeout(Duration.ofSeconds(5).toMillis()) {
-                Either.Right(Message(simName, "Update simulation timeout. Please check simulation is registered and reponsive."))
-            }
+        } catch (exception: Exception) {
+            result = Either.Right(Message("Optimizer", "Unexpected error happened when update simulation $simName failed. Please check simulation is registered and responsive. Cause:\n$exception"))
         }
 
         if (result.isLeft()) {
             modelService.updateSim(result.left().get())
         } else {
-            modelService.addMessage(result.right().get())
+            eventBus.post(NewMessageEvent(result.right().get()))
         }
-
     }
 
     override fun stopOptimization(request: StopOptimizationCommandDTO, responseObserver: StreamObserver<StopOptimizationResponseDTO>) = responseObserver.consume {
-        GlobalScope.async{ stopOptimization() }
+        GlobalScope.async { stopOptimization() }
         StopOptimizationResponseDTO.newBuilder().setMessage("Stop acknowledged").setStopped(true).build()
     }
 
     override fun offerSimulationResult(request: SimulationResponseDTO, responseObserver: StreamObserver<SimulationResultConfirmDTO>) = responseObserver.consume {
-        val output = modelService.simByName[request.name]?.output
+        val output = modelService.simulations.getNamed(request.name)?.output
         if (output != null) {
             output.send(request)
         } else {
@@ -214,7 +232,7 @@ class OptimizerEndpoint(
     }
 
     override fun offerErrorResult(request: ErrorResponseDTO, responseObserver: StreamObserver<ErrorConfirmDTO>) = responseObserver.consume {
-        val error = modelService.simByName[request.name]?.error
+        val error = modelService.simulations.getNamed(request.name)?.error
         if (error != null) {
             error.send(request)
         } else {
@@ -224,7 +242,7 @@ class OptimizerEndpoint(
     }
 
     override fun offerSimulationConfig(request: NodeStatusCommandOrResponseDTO, responseObserver: StreamObserver<NodeChangeConfirmDTO>) = responseObserver.consume {
-        val update = modelService.simByName[request.name]?.update
+        val update = modelService.simulations.getNamed(request.name)?.update
 
         if (update != null) {
             update.send(request)
@@ -237,29 +255,23 @@ class OptimizerEndpoint(
     override fun updateNode(request: NodeStatusCommandOrResponseDTO, responseObserver: StreamObserver<NodeChangeConfirmDTO>) = responseObserver.consume {
         val newNode = updateFromResponse(request)
         modelService.updateSim(newNode)
-        modelService.updateStatusMessage("${request.name} updated")
+        eventBus.post(StatusUpdateEvent("${request.name} updated"))
         NodeChangeConfirmDTO.newBuilder().setMessage("Simulation updated with inputs: ${newNode.inputs} outputs: ${newNode.outputs}").build()
     }
 
 
     override fun sendMessage(request: MessageCommandDTO, responseObserver: StreamObserver<MessageReponseDTO>) = responseObserver.consume {
-        println("Message from [${request.name}] : ${request.message}")
-        modelService.addMessage(Message(request.name, request.message))
+        eventBus.post(NewMessageEvent(Message(request.name, request.message)))
         MessageReponseDTO.newBuilder().build()
     }
 
     override fun unregister(request: UnRegistrationRequestDTO, responseObserver: StreamObserver<UnRegistrationResponseDTO>) = responseObserver.consume {
-        var unregistered = false
-        if (request.name in modelService.simByName.keys) {
-            val name = request.name
-            modelService.removeSim(name)
-            unregistered = true
-        }
+        val unregistered = modelService.closeSim(request.name)
         UnRegistrationResponseDTO.newBuilder().setUnregistered(unregistered).build()
     }
 
     private fun updateFromResponse(request: NodeStatusCommandOrResponseDTO): Simulation {
-        return modelService.simByName.getValue(request.name).copy(
+        return modelService.simulations.single { it.name == request.name }.copy(
                 name = request.name,
                 inputs = request.inputsList.map { Input(it.name, it.lowerBound, it.upperBound, it.currentValue) },
                 outputs = request.outputsList.map { Output(it.name) },

--- a/oasis-reference/src/main/resources/com.empowerops.volition.ref_oasis/OptimizerView.fxml
+++ b/oasis-reference/src/main/resources/com.empowerops.volition.ref_oasis/OptimizerView.fxml
@@ -8,11 +8,12 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.Tab?>
-<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.control.TreeTableColumn?>
 <?import javafx.scene.control.TreeTableView?>
 <?import javafx.scene.layout.AnchorPane?>
@@ -24,7 +25,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <AnchorPane fx:id="view" xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.empowerops.volition.ref_oasis.OptimizerController">
-    <BorderPane layoutX="110.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+    <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <top>
             <MenuBar BorderPane.alignment="CENTER">
                 <Menu mnemonicParsing="false" text="File">
@@ -37,137 +38,146 @@
                 <padding>
                     <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                 </padding>
-                <VBox spacing="5.0">
-                    <Label text="Log" />
-                    <TabPane VBox.vgrow="SOMETIMES">
-                        <Tab closable="false" text="Message Log">
-                            <AnchorPane>
-                                <TableView fx:id="messageTableView" prefHeight="200.0" prefWidth="750.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                    <columns>
-                                        <TableColumn fx:id="messageSenderColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Sender" />
-                                        <TableColumn fx:id="timeColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Time" />
-                                        <TableColumn fx:id="messageColumn" text="Message" />
-                                    </columns>
-                                    <columnResizePolicy>
-                                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                                    </columnResizePolicy>
-                                </TableView>
-                            </AnchorPane>
-                        </Tab>
-                        <Tab closable="false" text="Result Log">
-                            <AnchorPane>
-                                <TableView fx:id="resultTableView" prefHeight="200.0" prefWidth="750.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                    <columns>
-                                        <TableColumn fx:id="resultSenderColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Sender" />
-                                        <TableColumn fx:id="typeColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Status" />
-                                        <TableColumn fx:id="inputColumn" text="Input" />
-                                        <TableColumn fx:id="outputColumn" text="Output" />
-                                    </columns>
-                                    <columnResizePolicy>
-                                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                                    </columnResizePolicy>
-                                </TableView>
-                            </AnchorPane>
-                        </Tab>
-                    </TabPane>
-                </VBox>
+                <SplitPane dividerPositions="0.35">
+                    <AnchorPane>
+                        <TitledPane collapsible="false" text="Messages" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                            <TableView fx:id="messageTableView" prefHeight="200.0" prefWidth="750.0">
+                                <columns>
+                                    <TableColumn fx:id="messageSenderColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Sender" />
+                                    <TableColumn fx:id="timeColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Time" />
+                                    <TableColumn fx:id="messageColumn" text="Message" />
+                                </columns>
+                                <columnResizePolicy>
+                                    <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                                </columnResizePolicy>
+                            </TableView>
+                        </TitledPane>
+                    </AnchorPane>
+                    <AnchorPane>
+                        <TitledPane collapsible="false" text="Results" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                            <TableView fx:id="resultTableView" prefHeight="200.0" prefWidth="750.0">
+                                <columns>
+                                    <TableColumn fx:id="resultSenderColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Sender" />
+                                    <TableColumn fx:id="typeColumn" maxWidth="150.0" minWidth="150.0" prefWidth="150.0" text="Status" />
+                                    <TableColumn fx:id="inputColumn" text="Input" />
+                                    <TableColumn fx:id="outputColumn" text="Output" />
+                                </columns>
+                                <columnResizePolicy>
+                                    <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                                </columnResizePolicy>
+                            </TableView>
+                        </TitledPane>
+                    </AnchorPane>
+                </SplitPane>
                 <HBox>
                     <Label fx:id="optimizerStatusLabel" text="Status" />
                 </HBox>
             </VBox>
         </bottom>
         <center>
-            <VBox fx:id="selectedNodeInfoBox" spacing="5.0">
-                <VBox>
-                    <Label text="Configuration" />
-                    <HBox spacing="5.0">
-                        <Label text="Status: " />
-                        <Label fx:id="statusLabel" layoutX="10.0" layoutY="10.0" text="[Status]" />
-                    </HBox>
-                    <HBox spacing="5.0">
-                        <Label text="Description: " />
-                        <Label fx:id="descriptionLabel" layoutX="10.0" layoutY="10.0" text="[Description]" />
-                    </HBox>
-                    <HBox alignment="CENTER_LEFT" layoutX="10.0" layoutY="44.0" spacing="5.0">
-                        <CheckBox fx:id="useTimeout" />
-                        <Label text="Time Out:" />
-                        <TextField fx:id="timeOutTextField" />
-                        <Label text="in milliseconds" />
-                    </HBox>
-                    <Label layoutX="10.0" layoutY="10.0" text="Paramaters:" />
-                    <TreeTableView fx:id="paramTreeView">
-                        <columns>
-                            <TreeTableColumn fx:id="nameColumn" prefWidth="75.0" text="Parameter" />
-                            <TreeTableColumn fx:id="valueColumn" prefWidth="75.0" text="Value" />
-                            <TreeTableColumn fx:id="lbColumn" prefWidth="75.0" text="Lower Bound" />
-                            <TreeTableColumn fx:id="upColumn" prefWidth="75.0" text="Upper Bound" />
-                        </columns>
-                        <columnResizePolicy>
-                            <TreeTableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                        </columnResizePolicy>
-                    </TreeTableView>
-                </VBox>
-                <VBox VBox.vgrow="ALWAYS">
-                    <Label text="Simluation Actions" />
-                    <HBox spacing="5.0">
-                        <Button mnemonicParsing="false" onAction="#cancelRun" text="Cancel Workload"/>
-                        <Button mnemonicParsing="false" onAction="#refresh" text="Refresh"/>
-                    </HBox>
-                </VBox>
-                <padding>
+            <AnchorPane>
+                <BorderPane.margin>
                     <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                </padding>
-            </VBox>
+                </BorderPane.margin>
+                <TitledPane animated="false" collapsible="false" prefHeight="530.0" prefWidth="762.0" text="Simulation Setup" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                    <HBox spacing="10.0">
+                        <ListView fx:id="nodesList" maxWidth="200.0" minWidth="150.0" />
+                        <VBox fx:id="selectedNodeInfoBox" HBox.hgrow="ALWAYS">
+                            <HBox alignment="CENTER_LEFT">
+                                <Label text="Configuration" />
+                                <HBox HBox.hgrow="ALWAYS" />
+                                <Button mnemonicParsing="false" onAction="#removeSelectedSetup" text="Remove" />
+                            </HBox>
+                            <HBox spacing="5.0">
+                                <Label text="Description: " />
+                                <Label fx:id="descriptionLabel" layoutX="10.0" layoutY="10.0" text="[Description]" />
+                            </HBox>
+                            <HBox alignment="CENTER_LEFT" layoutX="10.0" layoutY="44.0" spacing="5.0">
+                                <CheckBox fx:id="useTimeout" />
+                                <Label text="Time Out:" />
+                                <TextField fx:id="timeOutTextField" />
+                                <Label text="in milliseconds" />
+                            </HBox>
+                            <Label layoutX="10.0" layoutY="10.0" text="Paramaters:" />
+                            <TreeTableView fx:id="paramTreeView" VBox.vgrow="ALWAYS" editable="true">
+                                <columns>
+                                    <TreeTableColumn fx:id="nameColumn" prefWidth="75.0" text="Parameter" />
+                                    <TreeTableColumn fx:id="valueColumn" prefWidth="75.0" text="Value" />
+                                    <TreeTableColumn fx:id="lbColumn" prefWidth="75.0" text="Lower Bound"/>
+                                    <TreeTableColumn fx:id="upColumn" prefWidth="75.0" text="Upper Bound"/>
+                                </columns>
+                                <columnResizePolicy>
+                                    <TreeTableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                                </columnResizePolicy>
+                            </TreeTableView>
+                        </VBox>
+                    </HBox>
+                </TitledPane>
+            </AnchorPane>
         </center>
         <right>
             <VBox spacing="5.0">
-                <Label text="General Actions" />
-                <GridPane hgap="5.0" vgap="5.0">
-                    <columnConstraints>
-                        <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="75.0" minWidth="75.0" prefWidth="75.0" />
-                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                    </columnConstraints>
-                    <rowConstraints>
-                        <RowConstraints vgrow="NEVER" />
-                        <RowConstraints vgrow="NEVER" />
-                        <RowConstraints vgrow="NEVER" />
-                        <RowConstraints vgrow="NEVER" />
-                    </rowConstraints>
-                    <Label text="Optimization" />
-                    <Label text="Configuration" GridPane.rowIndex="3" />
-                    <Button mnemonicParsing="false" onAction="#stopRun" text="Stop" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                    <Button mnemonicParsing="false" onAction="#startRun" text="Start" GridPane.columnIndex="1" />
-                    <Button disable="true" layoutX="110.0" layoutY="175.0" mnemonicParsing="false" text="Pause" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-                    <Button mnemonicParsing="false" onAction="#syncAll" text="Sync All Nodes" GridPane.columnIndex="1" GridPane.rowIndex="3" />
-                </GridPane>
-                <Label layoutX="10.0" layoutY="10.0" text="Debug Actions" />
-                <GridPane hgap="5.0" layoutX="10.0" layoutY="32.0" vgap="5.0">
-                    <columnConstraints>
-                        <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="75.0" minWidth="75.0" prefWidth="75.0" />
-                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                    </columnConstraints>
-                    <rowConstraints>
-                        <RowConstraints vgrow="NEVER" />
-                        <RowConstraints vgrow="NEVER" />
-                    </rowConstraints>
-                    <Label layoutX="18.0" layoutY="104.0" text="Cancel All" />
-                    <Label text="Cancel-Stop" GridPane.rowIndex="1" />
-                    <Button mnemonicParsing="false" onAction="#cancelAll" text="Cancel All" GridPane.columnIndex="1" />
-                    <Button layoutX="90.0" layoutY="130.0" mnemonicParsing="false" onAction="#cancelAndStop" text="Cancel and Stop" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                </GridPane>
+                <TitledPane animated="false" collapsible="false" text="Actions">
+                    <HBox>
+                        <VBox>
+                            <Label text="General Actions" />
+                            <GridPane hgap="5.0" vgap="5.0">
+                                <columnConstraints>
+                                    <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="75.0" minWidth="75.0" prefWidth="75.0" />
+                                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                </columnConstraints>
+                                <rowConstraints>
+                                    <RowConstraints vgrow="NEVER" />
+                                    <RowConstraints vgrow="NEVER" />
+                                    <RowConstraints vgrow="NEVER" />
+                                </rowConstraints>
+                                <Label text="Optimization" />
+                                <Button mnemonicParsing="false" onAction="#stopRun" text="Stop" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                                <Button mnemonicParsing="false" onAction="#startRun" text="Start" GridPane.columnIndex="1" />
+                                <Button fx:id="pauseButton" mnemonicParsing="false" onAction="#pauseRun" text="Pause" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                            </GridPane>
+                        </VBox>
+                        <VBox>
+                            <Label text="Debug Actions" />
+                            <GridPane hgap="5.0" vgap="5.0">
+                                <columnConstraints>
+                                    <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="75.0" minWidth="75.0" prefWidth="75.0" />
+                                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                </columnConstraints>
+                                <rowConstraints>
+                                    <RowConstraints vgrow="NEVER" />
+                                    <RowConstraints vgrow="NEVER" />
+                                </rowConstraints>
+                                <Label layoutX="18.0" layoutY="104.0" text="Cancel All" />
+                                <Label text="Cancel-Stop" GridPane.rowIndex="1" />
+                                <Button mnemonicParsing="false" onAction="#cancelAll" text="Cancel All" GridPane.columnIndex="1" />
+                                <Button layoutX="90.0" layoutY="130.0" mnemonicParsing="false" onAction="#cancelAndStop" text="Cancel and Stop" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                            </GridPane>
+                        </VBox>
+                    </HBox>
+                </TitledPane>
+                <AnchorPane VBox.vgrow="ALWAYS">
+                    <TitledPane collapsible="false" text="Issues" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                        <TextArea fx:id="issuesTextArea" editable="false" promptText="All clear" wrapText="true" />
+                    </TitledPane>
+                </AnchorPane>
                 <padding>
                     <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                 </padding>
             </VBox>
         </right>
         <left>
-            <VBox spacing="5.0" BorderPane.alignment="CENTER">
-                <Label text="Connected Simulation" />
-                <ListView fx:id="nodesList" VBox.vgrow="ALWAYS" />
-                <padding>
+            <AnchorPane minWidth="250.0">
+                <BorderPane.margin>
                     <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                </padding>
-            </VBox>
+                </BorderPane.margin>
+                <TitledPane animated="false" collapsible="false" prefHeight="46.0" prefWidth="117.0" text="Connected Plugins" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                    <VBox fx:id="connectionListContainer">
+                  <padding>
+                     <Insets bottom="1.0" left="1.0" right="1.0" top="1.0" />
+                  </padding></VBox>
+                </TitledPane>
+            </AnchorPane>
         </left>
     </BorderPane>
 </AnchorPane>


### PR DESCRIPTION
This is a PR for #10 
- 2 stage model added
- A bit update on register and unregister flow, now unregister on the optimizer service side will be calling `onComplete()` on the StreamObserver, plugin will treat that as Unregistered. This **temporally** solve the problem of no way of telling whether plugin is registered on its initial registration request by closing on StreamObserver. This also apply to the plugin side.
- New UI using tornadofx for the registered simulation list with its control
- New UI for modifying the bound of input symbols
- New UI for basic problem finding system, however, issues is only for display and not yet blocking a start
- Kind of adding the pause. currently lacking of a transition state making this less prefect, but it will do the job. Stop during a pause will still stop. 
- Result update on timeout are no longer waiting on cancel finished, but the whole evaluation loop still does. This means a time out will update result immediately but the next run will only start until the cancel returned. There is no more TimeOut Failure result for user in result.

