### PR TITLE
12 add headless support

### DIFF
--- a/api/src/main/kotlin/com/empowerops/volition/dto/grpc-extensions.kt
+++ b/api/src/main/kotlin/com/empowerops/volition/dto/grpc-extensions.kt
@@ -38,7 +38,31 @@ suspend fun <T, R> wrapToSuspend(call: (T, StreamObserver<R>) -> Unit, outboundM
     }
 }
 
-fun <T> StreamObserver<T>.consume(block: suspend () -> T) {
+fun <T> StreamObserver<T>.consume(block: () -> T) {
+    try {
+        val result = block()
+        onNext(result)
+    } catch (ex: Exception) {
+        onError(ex)
+        throw ex
+    } finally {
+        onCompleted()
+    }
+}
+
+fun <T> StreamObserver<T>.consumeThen(result : T, block2:(T) -> Unit) {
+    try {
+        onNext(result)
+    } catch (ex: Exception) {
+        onError(ex)
+        throw ex
+    } finally {
+        onCompleted()
+        block2(result)
+    }
+}
+
+fun <T> StreamObserver<T>.consumeAsync(block: suspend () -> T) {
      GlobalScope.launch {
         try {
             val result = block()
@@ -52,7 +76,11 @@ fun <T> StreamObserver<T>.consume(block: suspend () -> T) {
     }
 }
 
-class LoggingInterceptor(val output: Appendable): ServerInterceptor {
+interface Logger{
+    fun log(message:String, sender: String)
+}
+
+class LoggingInterceptor(val logger: Logger): ServerInterceptor {
 
     override fun <T : Any?, R : Any?> interceptCall(
             call: ServerCall<T, R>,
@@ -75,8 +103,9 @@ class LoggingInterceptor(val output: Appendable): ServerInterceptor {
             }
 
             override fun sendMessage(message: R) {
-                output.appendln("$name: $fullMethodName")
-                output.appendln(message.toString())
+                val messageString = message.toString().let { if(it.isBlank()) "[empty message]" else "\n$it"}
+
+                logger.log("$name: $fullMethodName $messageString", "API")
                 super.sendMessage(message)
             }
         }
@@ -86,13 +115,13 @@ class LoggingInterceptor(val output: Appendable): ServerInterceptor {
         val inboundInterceptor = object: ForwardingServerCallListener.SimpleForwardingServerCallListener<T>(actual) {
             override fun onComplete() {
                 if( ! type.serverSendsOneMessage()){
-                    output.append("CLOSED: $fullMethodName")
+                    logger.log("$fullMethodName", "API CLOSED")
                 }
                 actual.onComplete()
             }
             override fun onMessage(message: T) {
-                output.appendln("INBOUND: $fullMethodName")
-                output.appendln(message.toString())
+                val messageString = message.toString().let { if(it.isBlank()) "[empty message]" else "\n$it" }
+                logger.log("$fullMethodName $messageString", "API INBOUND")
                 actual.onMessage(message)
             }
         }

--- a/api/src/main/proto/optimizer.proto
+++ b/api/src/main/proto/optimizer.proto
@@ -71,34 +71,51 @@ service Optimizer {
     //   https://github.com/protocolbuffers/protobuf/issues/1606
 
     // entry-point, returns stream of OASIS queries/commands
-    rpc register (RegistrationCommandDTO) returns (stream OASISQueryDTO) {}
-    rpc unregister (UnRegistrationRequestDTO) returns (UnRegistrationResponseDTO) {}
+    rpc registerRequest (RequestRegistrationCommandDTO) returns (stream RequestQueryDTO) {}
+    rpc unregisterRequest (RequestUnRegistrationRequestDTO) returns (UnRegistrationResponseDTO) {}
 
     // commands/queries to OASIS
     rpc startOptimization (StartOptimizationCommandDTO) returns (StartOptimizationResponseDTO) {}
-    rpc StopOptimization (StopOptimizationCommandDTO) returns (StopOptimizationResponseDTO) {}
+    rpc stopOptimization (StopOptimizationCommandDTO) returns (StopOptimizationResponseDTO) {}
 
     // responses to OASIS supplied queries
     rpc offerSimulationResult (SimulationResponseDTO) returns (SimulationResultConfirmDTO) {}
     rpc offerSimulationConfig (NodeStatusCommandOrResponseDTO) returns (NodeChangeConfirmDTO) {}
     rpc offerErrorResult (ErrorResponseDTO) returns (ErrorConfirmDTO) {}
 
-    rpc sendMessage (MessageCommandDTO) returns (MessageReponseDTO) {}
+    rpc sendMessage (MessageCommandDTO) returns (MessageResponseDTO) {}
     rpc updateNode (NodeStatusCommandOrResponseDTO) returns (NodeChangeConfirmDTO) {}
+    rpc autoConfigure (NodeStatusCommandOrResponseDTO) returns (NodeChangeConfirmDTO) {}
     rpc changeNodeName (NodeNameChangeCommandDTO) returns (NodeNameChangeResponseDTO) {}
+
+    rpc updateConfiguration(ConfigurationCommandDTO) returns (ConfigurationResponseDTO) {}
+    rpc requestRunResult(ResultRequestDTO) returns (ResultResponseDTO) {}
+}
+
+message ConfigurationCommandDTO {
+    string name = 1;
+    Config config = 2;
+    message Config{
+        int64 timeout = 2;
+    }
+}
+
+message ConfigurationResponseDTO {
+    string name = 1;
+    string message =2;
 }
 
 //register
-message RegistrationCommandDTO {
+message RequestRegistrationCommandDTO {
     string name = 1;
 }
 
-message UnRegistrationRequestDTO {
+message RequestUnRegistrationRequestDTO {
     string name = 1;
 }
 
 message UnRegistrationResponseDTO {
-    bool unregistered = 1;
+    string message = 1;
 }
 
 message MessageCommandDTO {
@@ -106,14 +123,15 @@ message MessageCommandDTO {
     string message = 2;
 }
 
-message MessageReponseDTO {
-}
+message MessageResponseDTO {}
 
-message OASISQueryDTO {
+message RequestQueryDTO {
     oneof request {
         SimulationEvaluationRequest evaluationRequest = 1;
         NodeStatusUpdateRequest nodeStatusRequest = 2;
         SimulationCancelRequest cancelRequest = 3;
+        SimulationStartedRequest startRequest = 4;
+        SimulationStoppedRequest stopRequest = 5;
     }
 
     message SimulationEvaluationRequest {
@@ -128,23 +146,64 @@ message OASISQueryDTO {
     message SimulationCancelRequest {
         string name = 1;
     }
+
+    message SimulationStartedRequest {
+        string name = 1;
+        string runID = 2;
+    }
+
+    message SimulationStoppedRequest {
+        string name = 1;
+        string runID = 2;
+    }
 }
 
 //startOptimization
-message StartOptimizationCommandDTO {}
-message StartOptimizationResponseDTO {
-    //TODO: uuid
-    string message = 1;
-    bool started = 2;
+message StartOptimizationCommandDTO {
+    string name = 1;
+}
+message StartOptimizationResponseDTO {  //response: if a run can not start, a message of reason will be returned. If started, run ID will be returned
+    oneof response{
+        string message = 1;
+        string runID = 2;
+    }
 }
 
 //stopOptimization
 message StopOptimizationCommandDTO {
-    //TODO: uuid
+    string name = 1;
+    string id = 2;
 }
+
 message StopOptimizationResponseDTO {
-    string message = 1;
-    bool stopped = 2;
+    oneof response{
+        string message = 1;
+        string runID = 2;
+    }
+}
+
+//request result
+message ResultRequestDTO {
+    string name = 1;
+    string runID = 2;
+}
+
+message ResultResponseDTO {
+    oneof response {
+        string message = 1;
+        RunResult RunResult = 2;
+    }
+}
+
+message RunResult{
+    string runID = 1;
+    repeated Design point = 2;
+    repeated Design optimum = 3; //Best value for single run and pareto frontier for multiple objective
+}
+
+message Design {
+    map<string, double> input = 1;
+    map<string, double> output = 2;
 }
 
 //updateNode
@@ -167,6 +226,7 @@ message NodeNameChangeCommandDTO {
 }
 message NodeNameChangeResponseDTO {
     bool changed = 1;
+    string message = 2;
 }
 
 //offerNodeUpdate
@@ -176,7 +236,6 @@ message NodeStatusCommandOrResponseDTO {
     string description = 6;
     repeated PrototypeInputParameter inputs = 2;
     repeated PrototypeOutputParameter outputs = 3;
-    repeated ConfigurationProblem problems = 4;
 
     message PrototypeInputParameter {
         string name = 1;
@@ -194,10 +253,6 @@ message NodeStatusCommandOrResponseDTO {
         oneof currentValue {
             double value = 2;
         }
-    }
-
-    message ConfigurationProblem {
-        string message = 1;
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,7 @@ project('oasis-reference'){
         compile project(":api")
         compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.2'
         compile 'no.tornado:tornadofx:1.7.17'
+        compile 'info.picocli:picocli:3.9.5'
         compile group: 'org.funktionale', name: 'funktionale-all', version: '1.2'
     }
 

--- a/client-reference/src/main/kotlin/com/empowerops/volition/ref_client/client.kt
+++ b/client-reference/src/main/kotlin/com/empowerops/volition/ref_client/client.kt
@@ -58,7 +58,7 @@ object Client {
     suspend fun register() = withContext(Dispatchers.JavaFx) {
 
         try {
-            val channel = wrapToServerSideChannel(service::register, makeRegisterRequest())
+            val channel = wrapToServerSideChannel(service::registerRequest, makeRegisterRequest())
             registered = true
 
             //yeah so, this is an excellent demonstration of why coroutines matter..
@@ -68,7 +68,6 @@ object Client {
 
                     val result = try {
                         simulating = true
-//                        delay(3000)
                         makeWorkResult()
                     }
                     finally {
@@ -109,7 +108,7 @@ object Client {
     private fun makeOptimizationRequest() = StartOptimizationCommandDTO.newBuilder()
             .build()
 
-    private fun makeRegisterRequest() = RegistrationCommandDTO.newBuilder()
+    private fun makeRegisterRequest() = RequestRegistrationCommandDTO.newBuilder()
             .setName("cansys")
             .build()
 

--- a/csharp-client-reference/EmpowerOps.Volition.ClientRef.csproj
+++ b/csharp-client-reference/EmpowerOps.Volition.ClientRef.csproj
@@ -68,6 +68,12 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="EvaluationException.cs" />
+    <Compile Include="EvaluationResult.cs" />
+    <Compile Include="IEvaluator.cs" />
+    <Compile Include="Input.cs" />
+    <Compile Include="Output.cs" />
+    <Compile Include="RandomNumberEvaluator.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -132,29 +138,23 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Grpc.Core.1.16.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.16.0\build\net45\Grpc.Core.targets'))" />
   </Target>
-  
   <!-- create releasable zip -->
   <Target Name="AfterBuild">
     <Message Text="creating zip file for output folder" />
-
     <GetAssemblyIdentity AssemblyFiles="$(OutputPath)\Empowerops.Volition.Api.dll">
       <Output TaskParameter="Assemblies" ItemName="Targets" />
     </GetAssemblyIdentity>
     <ItemGroup>
-      <VersionNumber Include="@(Targets->'%(Version)')"/>
+      <VersionNumber Include="@(Targets->'%(Version)')" />
     </ItemGroup>
     <PropertyGroup>
       <VersionString>@(VersionNumber)</VersionString>
     </PropertyGroup>
-
-    <MakeDir Directories="Artifacts"/>
-    
+    <MakeDir Directories="Artifacts" />
     <ItemGroup>
       <FilesToClean Include="Artifacts\EmpowerOps.Volition.RefClient-*.zip" />
     </ItemGroup>
-    <Delete Files="@(FilesToClean)"/>
-    
-    <ZipDirectory SourceDirectory="$(OutputPath)" DestinationFile="Artifacts/EmpowerOps.Volition.RefClient-$(VersionString).zip" Overwrite="true"/>
-    
+    <Delete Files="@(FilesToClean)" />
+    <ZipDirectory SourceDirectory="$(OutputPath)" DestinationFile="Artifacts/EmpowerOps.Volition.RefClient-$(VersionString).zip" Overwrite="true" />
   </Target>
 </Project>

--- a/csharp-client-reference/EvaluationException.cs
+++ b/csharp-client-reference/EvaluationException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace EmpowerOps.Volition.RefClient
+{
+    public class EvaluationException : Exception {
+        public EvaluationException(string message) : base(message)
+        {
+        }
+    }
+
+}

--- a/csharp-client-reference/EvaluationResult.cs
+++ b/csharp-client-reference/EvaluationResult.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EmpowerOps.Volition.RefClient
+{
+    public class EvaluationResult
+    {
+        public enum ResultStatus
+        {
+            Succeed, Failed, Canceled
+        }
+
+        public ResultStatus Status { get; set; }
+        public Exception Exception { get; set; }
+       
+        public IDictionary<string, double> Output { get; set; }
+        public IDictionary<string, double> Input { get; set; }
+
+    }
+
+}

--- a/csharp-client-reference/IEvaluator.cs
+++ b/csharp-client-reference/IEvaluator.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace EmpowerOps.Volition.RefClient
+{
+    public interface IEvaluator
+    {
+        Task<EvaluationResult> EvaluateAsync(IDictionary<string, double> inputs, IList outputs);
+        void Cancel();
+        void SetFailNext();
+    }
+
+}

--- a/csharp-client-reference/Input.cs
+++ b/csharp-client-reference/Input.cs
@@ -1,0 +1,12 @@
+﻿namespace EmpowerOps.Volition.RefClient
+{
+    public class Input
+    {
+        public string Name { get; set; }
+        public double LowerBound { get; set; }
+        public double UpperBound { get; set; }
+        public double CurrentValue { get; set; }
+        public double EvaluatingValue { get; set; }
+    }
+
+}

--- a/csharp-client-reference/MainWindow.xaml
+++ b/csharp-client-reference/MainWindow.xaml
@@ -19,9 +19,10 @@
                 <MenuItem Header="_Exit" />
             </MenuItem>
         </Menu>
-      
+
         <Grid Margin="5" DockPanel.Dock="Left" Width="350">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="87*"/>
@@ -32,11 +33,24 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <Button Name="StartOptimization" Content="Start Optimization" Grid.Column="0" Click="StartOptimization_Click"/>
-                <Button Name="SyncSetting" Content="Sync" Width="75" Grid.Column="2" Click="SyncButton_Click"/>
+                <Button Name="Update" Content="Update" Grid.Column="2" Click="UpdateButton_Click"/>
                 <Button Name="StopOptimization" Content="Stop Optimization" Grid.Column="1" Click="StopOptimization_Click"/>
+                <Button Content="Auto Setup" Grid.Column="3" Click="AutoSetupButton_Click"/>
+            </Grid>
+            <Grid Grid.Row="2" Margin="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Button Name ="ApplyTimeoutToSetup" Content="Apply" Grid.Column="2" Click="ApplyTimeout_Click" />
+                <Button Name ="RemoveTimeout" Content="Clear" Grid.Column="3" Click="ClearTimeout_Click" />
+                <TextBox Name ="TimeoutTextBox" Grid.Column="1" HorizontalAlignment="Left" TextWrapping="Wrap" Width="120"/>
+                <Label Content="Timeout(in millisec)" Grid.Column="0" HorizontalAlignment="Left" />
             </Grid>
             <Grid Grid.Row="0" Margin="2">
                 <Grid.ColumnDefinitions>
@@ -52,7 +66,7 @@
                 <Label Name="RegisterLabel" Grid.Column="4" Content="Status: Not Registered" />
                 <Button Name="RenameButton" Grid.Column="3" Content="Rename" Click="Rename_Button_Click"/>
             </Grid>
-            <Grid Grid.Row="2" Margin="2">
+            <Grid Grid.Row="3" Margin="2">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition/>
@@ -78,7 +92,7 @@
                     <Button Content="Remove" Grid.Row="0" Click="RemoveInput_Button_Click" Width="76" Grid.Column="2"/>
                 </Grid>
             </Grid>
-            <Grid Grid.Row="3" Margin="2">
+            <Grid Grid.Row="4" Margin="2">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition/>
@@ -103,13 +117,20 @@
             </Grid>
         </Grid>
         <Grid Margin="5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBox x:Name="LogInfoTextBox" TextWrapping="Wrap" Grid.ColumnSpan="1"/>
-            <Grid Grid.Column="1">
-                <Button Content="Fail Next" VerticalAlignment="Top" HorizontalAlignment="Left" Click="FailNextRun_Click" />
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBox x:Name="LogInfoTextBox" TextWrapping="Wrap" Grid.Row="0"/>
+            <Grid Margin="5" Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Button Content="Fail Next" Grid.Column="0" VerticalAlignment="Top" HorizontalAlignment="Left" Click="FailNextRun_Click" Grid.Row="1" />
+                <CheckBox x:Name="ForwardMessageCheckBox" Grid.Column="2" Content="Forward Message" HorizontalAlignment="Right" Grid.Row="1" VerticalAlignment="Center"/>
+                <Button Content="Request Result" Grid.Column="1" HorizontalAlignment="Left" Grid.Row="1" VerticalAlignment="Top" Click ="RequestResult_Click"/>
             </Grid>
         </Grid>
     </DockPanel>

--- a/csharp-client-reference/Output.cs
+++ b/csharp-client-reference/Output.cs
@@ -1,0 +1,10 @@
+﻿namespace EmpowerOps.Volition.RefClient
+{
+    public class Output
+    {
+        public string Name { get; set; }
+        public string CurrentValue { get; set; }
+        public string EvaluatingValue { get; set; }
+    }
+
+}

--- a/csharp-client-reference/RandomNumberEvaluator.cs
+++ b/csharp-client-reference/RandomNumberEvaluator.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EmpowerOps.Volition.RefClient
+{
+    public class RandomNumberEvaluator : IEvaluator
+    {
+        private CancellationTokenSource _evaluationCancellationTokenSource;
+        private bool _failToggle = false;
+
+        public void Cancel()
+        {
+            _evaluationCancellationTokenSource.Cancel();
+        }
+
+        public async Task<EvaluationResult> EvaluateAsync(IDictionary<string, double> inputs, IList outputs)
+        {
+            _evaluationCancellationTokenSource = new CancellationTokenSource();
+
+            try
+            {
+                return await EvaluationAsync(inputs, outputs, _evaluationCancellationTokenSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return new EvaluationResult { Input = inputs, Output = new Dictionary<string, double>(), Status = EvaluationResult.ResultStatus.Canceled };
+            }
+            catch (EvaluationException e)
+            {
+                var result = new Dictionary<string, double>();
+                foreach (Output output in outputs)
+                {
+                    var evaluationResult = Double.PositiveInfinity;
+                    result.Add(output.Name, evaluationResult);
+                }
+
+                return new EvaluationResult
+                {
+                    Input = inputs,
+                    Output = result,
+                    Status = EvaluationResult.ResultStatus.Failed,
+                    Exception = e
+                };
+            }
+            catch (Exception e)
+            {
+                return new EvaluationResult
+                {
+                    Input = inputs,
+                    Output = new Dictionary<string, double>(),
+                    Status = EvaluationResult.ResultStatus.Failed,
+                    Exception = e
+                };
+            }
+        }
+
+        private async Task<EvaluationResult> EvaluationAsync(IDictionary<string, double> inputs, IList outputs, CancellationToken ct)
+        {
+            await Task.Delay(1000);
+            ct.ThrowIfCancellationRequested();
+            if (_failToggle)
+            {
+                _failToggle = false;
+                throw new EvaluationException($"Error evaluating {inputs}");
+            }
+            await Task.Delay(4000);
+            ct.ThrowIfCancellationRequested();
+            var result = new Dictionary<string, double>();
+            var random = new Random();
+           
+            foreach (Output output in outputs)
+            {
+                var evaluationResult = random.NextDouble();
+                result.Add(output.Name, evaluationResult);
+            }
+
+            return new EvaluationResult { Input = inputs, Output = result, Status = EvaluationResult.ResultStatus.Succeed };
+        }
+
+        public void SetFailNext()
+        {
+            _failToggle = true;
+        }
+    }
+
+}

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ApiService.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ApiService.kt
@@ -1,0 +1,162 @@
+package com.empowerops.volition.ref_oasis
+
+import com.empowerops.volition.dto.*
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.stub.StreamObserver
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.util.*
+
+interface IApiService {
+    suspend fun offerResult(request: SimulationResponseDTO): SimulationResultConfirmDTO
+    suspend fun offerConfig(request: NodeStatusCommandOrResponseDTO): NodeChangeConfirmDTO
+    suspend fun offerError(request: ErrorResponseDTO): ErrorConfirmDTO
+    fun register(request: RequestRegistrationCommandDTO, responseObserver: StreamObserver<RequestQueryDTO>)
+    fun unregister(request: RequestUnRegistrationRequestDTO): UnRegistrationResponseDTO
+    fun sendMessage(request: MessageCommandDTO): MessageResponseDTO
+    fun updateNode(request: NodeStatusCommandOrResponseDTO): NodeChangeConfirmDTO
+    fun resultRequest(request: ResultRequestDTO): ResultResponseDTO
+    fun issueStopOptimization(request: StopOptimizationCommandDTO): StopOptimizationResponseDTO
+    fun issueStartOptimization(request: StartOptimizationCommandDTO): StartOptimizationResponseDTO
+    fun updateConfiguration(request: ConfigurationCommandDTO): ConfigurationResponseDTO
+    fun autoConfigure(request: NodeStatusCommandOrResponseDTO): NodeChangeConfirmDTO
+    fun changeNodeName(request: NodeNameChangeCommandDTO): NodeNameChangeResponseDTO
+    fun stop()
+    fun startAsync()
+}
+
+class ApiService(private val modelService: DataModelService,
+                 private val optimizerService: OptimizerService) : IApiService {
+
+    override fun register(request: RequestRegistrationCommandDTO, responseObserver: StreamObserver<RequestQueryDTO>) {
+        val added = modelService.addSim(createDefaultSimulationWithName(request.name, responseObserver))
+        if (!added) {
+            responseObserver.onError(StatusException(Status.ALREADY_EXISTS))
+        }
+    }
+
+    override suspend fun offerResult(request: SimulationResponseDTO): SimulationResultConfirmDTO {
+        modelService.simulations.getNamed(request.name)?.output.sendAndRespond(request)
+        return SimulationResultConfirmDTO.newBuilder().build()
+    }
+
+    override suspend fun offerConfig(request: NodeStatusCommandOrResponseDTO): NodeChangeConfirmDTO {
+        modelService.simulations.getNamed(request.name)?.update.sendAndRespond(request)
+        return NodeChangeConfirmDTO.newBuilder().build()
+    }
+
+    override suspend fun offerError(request: ErrorResponseDTO): ErrorConfirmDTO {
+        modelService.simulations.getNamed(request.name)?.error.sendAndRespond(request)
+        return ErrorConfirmDTO.newBuilder().build()
+    }
+
+    override fun unregister(request: RequestUnRegistrationRequestDTO): UnRegistrationResponseDTO {
+        val unregistered = modelService.closeSim(request.name)
+        return UnRegistrationResponseDTO.newBuilder().setMessage(buildUnregisterMessage(unregistered)).build()
+    }
+
+    override fun sendMessage(request: MessageCommandDTO): MessageResponseDTO {
+        modelService.addNewMessage(Message(request.name, request.message))
+        return MessageResponseDTO.newBuilder().build()
+    }
+
+    override fun updateNode(request: NodeStatusCommandOrResponseDTO): NodeChangeConfirmDTO {
+        val newSimulationConfig = request.generateUpdatedSimulation()
+        val updated = modelService.updateSimAndConfiguration(newSimulationConfig)
+
+        return NodeChangeConfirmDTO.newBuilder().setMessage(buildSimulationUpdateMessage(newSimulationConfig, updated)).build()
+    }
+
+    override fun issueStopOptimization(request: StopOptimizationCommandDTO): StopOptimizationResponseDTO {
+        val canStop = optimizerService.canStop()
+        val newBuilder = StopOptimizationResponseDTO.newBuilder()
+        return if(canStop){
+            newBuilder.setRunID(request.id).build()
+        }
+        else{
+            newBuilder.setMessage(buildStopMessage()).build()
+        }
+    }
+
+    override fun stop(){
+        optimizerService.stopOptimization()
+    }
+
+    override fun resultRequest(request: ResultRequestDTO): ResultResponseDTO {
+        val responseBuilder = ResultResponseDTO.newBuilder()
+        val list = modelService.resultList[UUID.fromString(request.runID)]
+        if (list == null) {
+            responseBuilder.message = buildRunNotFoundMessage(request)
+        } else {
+            val runResultBuilder = RunResult.newBuilder()
+            runResultBuilder.addAllPoint(list.map { Design.newBuilder().putAllInput(it.inputs).putAllOutput(it.result).build() })
+            runResultBuilder.addAllOptimum(emptyList())//TODO update optimum
+            responseBuilder.runResult = runResultBuilder.build()
+
+        }
+        return responseBuilder.build()
+    }
+
+    override fun issueStartOptimization(request: StartOptimizationCommandDTO): StartOptimizationResponseDTO {
+        val responseBuilder = StartOptimizationResponseDTO.newBuilder()
+        val reply = optimizerService.requestStart()
+        if (reply.isLeft()) {
+            responseBuilder.message = buildStartIssuesMessage(reply.left().get())
+        } else {
+            responseBuilder.runID = reply.right().get().toString()
+        }
+
+        return responseBuilder.build()
+    }
+
+    override fun startAsync() {
+        GlobalScope.launch {
+            optimizerService.startOptimization()
+        }
+    }
+
+
+    override fun updateConfiguration(request: ConfigurationCommandDTO): ConfigurationResponseDTO {
+        val durationSet = modelService.setDuration(request.name, Duration.ofMillis(request.config.timeout))
+        return ConfigurationResponseDTO.newBuilder().setMessage(buildUpdateMessage(durationSet)).build()
+    }
+
+    override fun autoConfigure(request: NodeStatusCommandOrResponseDTO): NodeChangeConfirmDTO {
+        val autoSetupResult = modelService.autoSetup(request.generateUpdatedSimulation())
+        return NodeChangeConfirmDTO.newBuilder().setMessage(buildAutoSetupMessage(autoSetupResult)).build()
+    }
+
+    override fun changeNodeName(request: NodeNameChangeCommandDTO): NodeNameChangeResponseDTO {
+        val changed = modelService.renameSim(newName = request.newName, oldName = request.oldName)
+        return NodeNameChangeResponseDTO.newBuilder().setChanged(changed).setMessage(buildNameChangeMessage(changed, request.oldName, request.newName)).build()
+    }
+
+    private suspend fun <T> Channel<T>?.sendAndRespond(request: T) {
+        if (this == null) throw IllegalStateException("no outChannel available for '$request' or buffer full")
+        send(request)
+    }
+
+    private fun NodeStatusCommandOrResponseDTO.generateUpdatedSimulation(): Simulation {
+        return modelService.simulations.single { it.name == name }.copy(
+                name = name,
+                inputs = inputsList.map { Input(it.name, it.lowerBound, it.upperBound, it.currentValue) },
+                outputs = outputsList.map { Output(it.name) },
+                description = description
+        )
+    }
+
+    internal fun createDefaultSimulationWithName(name: String, input: StreamObserver<RequestQueryDTO>) =
+            Simulation(name, emptyList(), emptyList(), "", input, Channel(Channel.RENDEZVOUS), Channel(Channel.RENDEZVOUS), Channel(Channel.RENDEZVOUS))
+
+    internal fun buildNameChangeMessage(changed: Boolean, oldName: String, newName: String) = "Name change request from $oldName to $newName ${if (changed) "succeed" else "failed"}"
+    internal fun buildUnregisterMessage(result: Boolean) = "Unregister ${if (result) "success" else "failed"}"
+    internal fun buildUpdateMessage(updated: Boolean) = "Configuration update request ${if (updated) "succeed" else "failed, there is no existing setup."}"
+    internal fun buildSimulationUpdateMessage(newNode: Simulation, updated: Boolean) = "Simulation updated with inputs: ${newNode.inputs} outputs: ${newNode.outputs} ${if (updated) "succeed" else "failed"}"
+    internal fun buildStartIssuesMessage(issues: List<String>) = "Optimization cannot start: ${issues.joinToString(", ")}"
+    internal fun buildRunNotFoundMessage(request: ResultRequestDTO) = "Requested run ID ${request.runID} is not available"
+    internal fun buildAutoSetupMessage(autoSetupResult: Boolean) = "Auto setup ${if (autoSetupResult) "succeed" else "failed"}"
+    internal fun buildStopMessage() = "Optimization stop order rejected"
+}

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ConnectionView.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ConnectionView.kt
@@ -13,7 +13,6 @@ import tornadofx.*
 
 class ConnectionView(
         val dataModel: DataModelService,
-        val control: OptimizerEndpoint,
         val eventBus: EventBus) : View("My View") {
 
 
@@ -57,8 +56,7 @@ class ConnectionView(
                     button("refresh") {
                         action {
                             GlobalScope.launch {
-                                control.updateNode(name)
-                                dataModel.syncConfiguration(name)
+                                dataModel.updateSimulation(name)
                             }
                         }
                     }
@@ -72,8 +70,7 @@ class ConnectionView(
                     button("add setup") {
                         action {
                             GlobalScope.launch {
-                                dataModel.addConfiguration(name)
-                                dataModel.syncConfiguration(name)
+                                dataModel.addAndSyncConfiguration(name)
                             }
                         }
                     }

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ConsoleOutput.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/ConsoleOutput.kt
@@ -1,0 +1,38 @@
+package com.empowerops.volition.ref_oasis
+
+import com.empowerops.volition.dto.Logger
+import com.google.common.eventbus.EventBus
+import com.google.common.eventbus.Subscribe
+import kotlinx.coroutines.channels.Channel
+import java.time.LocalDateTime
+import java.util.logging.Level
+
+/**
+ * TODO LIST:
+ * 1. Configurable level and verbosity
+ * 2. Using logging framework for persistence
+ * 3. Standard out/error streaming for connected client side (cloud)
+ * 4. Log/Logfile retrieval for client side (cloud)
+ */
+class ConsoleOutput(eventBus: EventBus) : Logger {
+    var log: List<Message> = emptyList()
+    val outChannel = Channel<String>(Channel.UNLIMITED)
+
+    init {
+        eventBus.register(this)
+    }
+
+    override fun log(message: String, sender : String) {
+        log += Message(sender, message)
+        val logMessage = "[${LocalDateTime.now()}] $sender > $message"
+        System.out.println(logMessage)
+    }
+
+    @Subscribe
+    fun onEvent(event : StatusUpdateEvent){
+        val message = Message("Optimizer Event", event.toString(), Level.INFO)
+        log += message
+        val logMessage = "[${LocalDateTime.now()}] > ${event.status}"
+        System.out.println(logMessage)
+    }
+}

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/DataModelService.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/DataModelService.kt
@@ -2,39 +2,31 @@ package com.empowerops.volition.ref_oasis
 
 import com.google.common.eventbus.EventBus
 import java.time.Duration
+import java.util.*
 
-interface Event
-interface ModelEvent : Event
-
-data class StatusUpdateEvent(val status: String) : Event
-data class NewMessageEvent(val message: Message) : Event
-data class NewResultEvent(val result: Result) : Event
-
-data class PluginRegisteredEvent(val name: String) : ModelEvent
-data class PluginUnRegisteredEvent(val name: String) : ModelEvent
-class PluginUpdatedEvent : ModelEvent
-data class PluginRenamedEvent(val oldName: String, val newName: String) : ModelEvent
-data class ProxyAddedEvent(val name: String) : ModelEvent
-data class ProxyRemovedEvent(val name: String) : ModelEvent
-data class ProxyRenamedEvent(val oldName: String, val newName: String) : ModelEvent
-class ProxyUpdatedEvent : ModelEvent
-
-fun <T : Nameable> List<T>.getValue(name: String) : T = single { it.name == name }
-fun <T : Nameable> List<T>.getNamed(name: String?) : T? = singleOrNull { it.name == name }
-fun <T : Nameable> List<T>.hasName(name: String?): Boolean = any { it.name == name }
-fun <T : Nameable> List<T>.replace(old: T, new: T) : List<T> = this - old + new
-fun <T : Nameable> List<T>.getNames(): List<String> = map{it.name}
-
-class DataModelService(private val eventBus: EventBus) {
+class DataModelService(private val eventBus: EventBus, private val overwriteMode : Boolean) {
     var simulations: List<Simulation> = emptyList()
+        private set
     var proxies: List<Proxy> = emptyList()
+        private set
+    var resultList : Map<UUID, List<EvaluationResult>> = emptyMap()
+        private set
+    var messageList : List<Message> = emptyList()
+        private set
 
+    /**
+     * Update the timeout for configuration by name
+     */
     fun setDuration(nodeName: String?, timeOut: Duration?) : Boolean{
         val oldNode = proxies.getNamed(nodeName) ?: return false
         proxies = proxies.replace(oldNode, oldNode.copy(timeOut = timeOut))
+        eventBus.post(ProxyUpdatedEvent(nodeName!!))
         return true
     }
 
+    /**
+     * Rename a simulation and, if possible, its associated configuration
+     */
     fun renameSim(newName: String, oldName: String): Boolean {
         val oldSim = simulations.getNamed(oldName) ?: return false
         if (simulations.hasName(newName)) return false
@@ -46,22 +38,29 @@ class DataModelService(private val eventBus: EventBus) {
 
     private fun renameProxy(newName: String, oldName: String): Boolean {
         val oldProxy = proxies.getNamed(oldName) ?: return false
-        if (proxies.hasName(newName)) return false
         proxies = proxies.replace(oldProxy, oldProxy.copy(name = newName))
         eventBus.post(ProxyRenamedEvent(oldName, newName))
         return true
     }
 
-    fun addNewSim(simulation: Simulation) : Boolean {
-        if (simulations.hasName(simulation.name)) return false
-
+    /**
+     * Add a new simulation
+     * will return false if simulation with same name already exist
+     */
+    fun addSim(simulation: Simulation) : Boolean {
+        if (simulations.hasName(simulation.name) && ! overwriteMode) return false
+        if(overwriteMode && simulations.hasName(simulation.name)){
+            removeSim(simulation.name)
+        }
         simulations += simulation
         eventBus.post(PluginRegisteredEvent(simulation.name))
         return true
     }
 
     /**
-     * try unregister a node and remove it
+     * Try unregister a simulation base on name and remove it regardless the result.
+     *
+     * This will also set the StreamObserver of request to completed so the holder of that should get notified
      */
     fun closeSim(name: String) : Boolean{
         val sim = simulations.getNamed(name) ?: return false
@@ -72,6 +71,9 @@ class DataModelService(private val eventBus: EventBus) {
         }
     }
 
+    /**
+     * Remove a simulation base on name. Will return false if requested simulation does not exist
+     */
     private fun removeSim(name: String) : Boolean {
         val sim = simulations.getNamed(name) ?: return false
         simulations -= sim
@@ -79,41 +81,79 @@ class DataModelService(private val eventBus: EventBus) {
         return true
     }
 
-    fun updateSim(newSim: Simulation) : Boolean{
+    /**
+     * Update simulation and, if possible, the associated configuration
+     */
+    fun updateSimAndConfiguration(newSim: Simulation) : Boolean{
         val oldSim = simulations.getNamed(newSim.name) ?: return false
         simulations = simulations.replace(oldSim, newSim)
-        eventBus.post(PluginUpdatedEvent())
-        return true
-    }
-
-    fun addConfiguration(name: String) : Boolean {
-        if (proxies.hasName(name)) return false
-        proxies += Proxy(name)
-        eventBus.post(ProxyAddedEvent(name))
+        eventBus.post(PluginUpdatedEvent(newSim.name))
+        syncConfigurationToSimulation(newSim.name)
         return true
     }
 
     /**
-     * Match the setup between proxy and its simulation
+     * Automatically add the configuration base on existing simulation
+     *
+     * This will:
+     * 1. Remove all the existing configuration
+     * 2. Update the existing simulation base on the request
+     * 3. Create and add a single configuration associated to the new simulation
      */
-    fun syncConfiguration(name: String) : Boolean{
+    fun autoSetup(newSim: Simulation) : Boolean {
+        if(! simulations.hasName(newSim.name)) return false
+
+        proxies.forEach { removeConfiguration(it.name) }
+        var result = true
+        result = result && updateSimAndConfiguration(newSim)
+        result = result && addAndSyncConfiguration(newSim.name)
+        return result
+    }
+
+    /**
+     * Add a new configuration base on exist simulation name
+     */
+    fun addAndSyncConfiguration(name: String) : Boolean {
+        if (proxies.hasName(name) || ! simulations.hasName(name)) return false
+        proxies += Proxy(name)
+        eventBus.post(ProxyAddedEvent(name))
+        syncConfigurationToSimulation(name)
+        return true
+    }
+
+    /**
+     * Refresh the configuration to match to the associated simulation's setup
+     */
+    private fun syncConfigurationToSimulation(name: String) : Boolean{
         val oldProxy = proxies.getNamed(name) ?: return false
         val sim = simulations.getNamed(name) ?: return false
         proxies = proxies.replace(oldProxy, Proxy(name, sim.inputs, sim.outputs, oldProxy.timeOut))
-        eventBus.post(ProxyUpdatedEvent())
+        eventBus.post(ProxyUpdatedEvent(name))
         return true
+    }
+
+    /**
+     * Request to retrieve the setup base on the registered connection name
+     *
+     * Simulation may or may not be updated and the result is up to Plugin Endpoint
+     */
+    fun updateSimulation(name: String){
+        eventBus.post(SimulationUpdateRequestedEvent(name))
     }
 
     /**
      * Match the setup between proxy and its simulation
      */
-    fun syncConfiguration(newProxy: Proxy) : Boolean{
+    fun updateConfiguration(newProxy: Proxy) : Boolean{
         val oldProxy = proxies.getNamed(newProxy.name) ?: return false
         proxies = proxies.replace(oldProxy, newProxy)
-        eventBus.post(ProxyUpdatedEvent())
+        eventBus.post(ProxyUpdatedEvent(newProxy.name))
         return true
     }
 
+    /**
+     * Remove a configuration with name
+     */
     fun removeConfiguration(name: String) : Boolean{
         val proxy = proxies.getNamed(name) ?: return false
         proxies -= proxy
@@ -121,12 +161,14 @@ class DataModelService(private val eventBus: EventBus) {
         return true
     }
 
-
     fun findIssue(): List<String> {
         var issues = emptyList<String>()
         val proxyNames = proxies.getNames()
         val simNames = simulations.getNames()
 
+        if(proxyNames.isEmpty()){
+            issues += "No proxy setup"
+        }
         val proxyWithNoMatchingSim = proxyNames - simNames
         if (proxyWithNoMatchingSim.isNotEmpty()) {
             proxyWithNoMatchingSim.forEach {
@@ -152,4 +194,16 @@ class DataModelService(private val eventBus: EventBus) {
         }
         return issues
     }
+
+    fun addNewResult(runID: UUID, result: EvaluationResult) {
+        val results = resultList.getOrElse(runID) { emptyList() }
+        resultList += runID to results + result
+        eventBus.post(NewResultEvent(result))
+    }
+
+    fun addNewMessage(message: Message) {
+        messageList += message
+        eventBus.post(NewMessageEvent(message))
+    }
+
 }

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Events.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Events.kt
@@ -1,0 +1,31 @@
+package com.empowerops.volition.ref_oasis
+
+import java.util.*
+
+interface Event
+interface ModelEvent : Event
+interface OptimizationModelEvent : ModelEvent
+
+open class StatusUpdateEvent(val status: String)                        : Event
+data class NewMessageEvent(val message: Message)                        : ModelEvent, StatusUpdateEvent("New message received: $message")
+data class NewResultEvent(val result: EvaluationResult)                 : ModelEvent, StatusUpdateEvent("New result received: $result")
+
+data class PluginUnRegisteredEvent(val name: String)                    : OptimizationModelEvent, StatusUpdateEvent("Plugin $name unregistered")
+data class PluginRegisteredEvent(val name: String)                      : OptimizationModelEvent, StatusUpdateEvent("Plugin $name registered")
+data class PluginUpdatedEvent(val name: String)                         : OptimizationModelEvent, StatusUpdateEvent("Plugin $name updated")
+data class PluginRenamedEvent(val oldName: String, val newName: String) : OptimizationModelEvent, StatusUpdateEvent("Plugin $oldName renamed to $newName")
+data class ProxyAddedEvent(val name: String)                            : OptimizationModelEvent, StatusUpdateEvent("Proxy $name added")
+data class ProxyRemovedEvent(val name: String)                          : OptimizationModelEvent, StatusUpdateEvent("Proxy $name removed")
+data class ProxyRenamedEvent(val oldName: String, val newName: String)  : OptimizationModelEvent, StatusUpdateEvent("Proxy $oldName renamed to $newName")
+data class ProxyUpdatedEvent(val name: String)                          : OptimizationModelEvent, StatusUpdateEvent("Proxy $name updated")
+
+data class PausedEvent(val id: UUID)    : StatusUpdateEvent("Run Paused  - ID:$id")
+data class RunStartedEvent(val id: UUID): StatusUpdateEvent("Run Started - ID:$id")
+data class RunStoppedEvent(val id: UUID): StatusUpdateEvent("Run Stopped - ID:$id")
+     class StartRequestedEvent          : StatusUpdateEvent("Run Requested")
+     class StopRequestedEvent           : StatusUpdateEvent("Stop Requested")
+     class ForceStopRequestedEvent      : StatusUpdateEvent("Force Stop Requested")
+     class PausedRequestedEvent         : StatusUpdateEvent("Pause Requested")
+     class RunResumedEvent              : StatusUpdateEvent("Run Resumed")
+
+class SimulationUpdateRequestedEvent(val name: String)                  : Event

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Models.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Models.kt
@@ -1,14 +1,12 @@
 package com.empowerops.volition.ref_oasis
 
-import com.empowerops.volition.dto.ErrorResponseDTO
-import com.empowerops.volition.dto.NodeStatusCommandOrResponseDTO
-import com.empowerops.volition.dto.OASISQueryDTO
-import com.empowerops.volition.dto.SimulationResponseDTO
+import com.empowerops.volition.dto.*
 import io.grpc.stub.StreamObserver
-import javafx.collections.ObservableMap
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import java.time.Duration
 import java.time.LocalDateTime
+import java.util.logging.Level
 
 data class Input(
         val name: String,
@@ -24,33 +22,79 @@ data class Output(
 data class Message(
         val sender: String,
         val message: String,
+        val level: Level = Level.INFO,
         val receiveTime: LocalDateTime = LocalDateTime.now()
 )
 
-data class Result(
-        val name: String,
-        val resultType: String,
-        val inputs: String,
-        val outputs: String
-)
+sealed class EvaluationResult(
+        open val name: String,
+        open val inputs: Map<String, Double> = emptyMap(),
+        open val result: Map<String, Double> = emptyMap()) {
+    data class Success(
+            override val name: String,
+            override val inputs: Map<String, Double>,
+            override val result: Map<String, Double>
+    ) : EvaluationResult(name, inputs, result)
 
-interface Nameable{
+    data class TimeOut(
+            override val name: String,
+            override val inputs: Map<String, Double>
+    ) : EvaluationResult(name, inputs)
+
+    data class Failed(
+            override val name: String,
+            override val inputs: Map<String, Double>,
+            val exception: String
+    ) : EvaluationResult(name, inputs)
+
+    data class Error(
+            override val name: String,
+            override val inputs: Map<String, Double>,
+            val exception: String
+    ) : EvaluationResult(name, inputs)
+
+    data class Terminated(
+            override val name: String,
+            override val inputs: Map<String, Double>,
+            val message: String
+    ): EvaluationResult(name, inputs)
+}
+
+
+
+sealed class CancelResult {
+    data class Canceled(val name: String) : CancelResult()
+    data class CancelFailed(val name: String, val exception: String) : CancelResult()
+}
+
+interface Nameable {
     val name: String
 }
+
+fun <T : Nameable> List<T>.getValue(name: String): T = single { it.name == name }
+fun <T : Nameable> List<T>.getNamed(name: String?): T? = singleOrNull { it.name == name }
+fun <T : Nameable> List<T>.hasName(name: String?): Boolean = any { it.name == name }
+fun <T : Nameable> List<T>.replace(old: T, new: T): List<T> = this - old + new
+fun <T : Nameable> List<T>.getNames(): List<String> = map { it.name }
 
 data class Simulation(
         override val name: String,
         val inputs: List<Input>,
         val outputs: List<Output>,
         val description: String,
-        val input: StreamObserver<OASISQueryDTO>,
+        val input: StreamObserver<RequestQueryDTO>,
         val output: Channel<SimulationResponseDTO>,
         val update: Channel<NodeStatusCommandOrResponseDTO>,
         val error: Channel<ErrorResponseDTO>
 ) : Nameable
 
+data class ForceStopSignal(
+        override val name: String,
+        val completableDeferred : CompletableDeferred<Unit> = CompletableDeferred()
+): Nameable
+
 data class Proxy(
-        override val name : String,
+        override val name: String,
         val inputs: List<Input> = emptyList(),
         val outputs: List<Output> = emptyList(),
         val timeOut: Duration? = null

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Optimizer.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/Optimizer.kt
@@ -3,46 +3,116 @@ package com.empowerops.volition.ref_oasis
 import com.empowerops.volition.dto.LoggingInterceptor
 import com.google.common.eventbus.EventBus
 import io.grpc.Server
-import io.grpc.ServerBuilder
 import io.grpc.ServerInterceptors
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import javafx.application.Application
-import javafx.fxml.FXMLLoader
-import javafx.scene.Parent
+import javafx.application.Platform
 import javafx.scene.Scene
 import javafx.stage.Stage
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import java.io.IOException
 
+/**
+ * TODO: Add a main not using javafx for headless
+ *
+ * Note:
+ * The only reason we are not having a another main calling console.run is I haven't figure out the release engineering part of this
+ */
 fun main(args: Array<String>) {
-    Application.launch(Optimizer::class.java)
+    Application.launch(OptimizerStarter::class.java, *args)
 }
 
-class Optimizer : Application() {
-    lateinit var server: Server
-    lateinit var endpoint: OptimizerEndpoint
-    lateinit var modelService: DataModelService
-    val eventBus: EventBus = EventBus()
+class OptimizerStarter : Application(){
+    private val optimizer = Optimizer()
 
     override fun start(primaryStage: Stage) {
-        val fxmlLoader = FXMLLoader()
-        val resourceAsStream = this.javaClass.classLoader.getResourceAsStream("com.empowerops.volition.ref_oasis/OptimizerView.fxml")
-        val root = fxmlLoader.load<Parent>(resourceAsStream)
-        val controller = fxmlLoader.getController<OptimizerController>()
-        primaryStage.title = "Volition Reference Optimizer"
-        primaryStage.scene = Scene(root)
-        primaryStage.show()
-
-        setupService()
-        val connectionView = ConnectionView(modelService, endpoint, eventBus)
-
-        controller.setData(modelService, endpoint, eventBus, connectionView.root)
+        val commandLine = CommandLine(optimizer)
+        try {
+            commandLine.parse(*parameters.raw.toTypedArray<String>())
+            when {
+                commandLine.isUsageHelpRequested -> {
+                    commandLine.usage(System.out)
+                    Platform.exit()
+                }
+                commandLine.isVersionHelpRequested -> {
+                    commandLine.printVersionHelp(System.out)
+                    Platform.exit()
+                }
+                else -> optimizer.start(primaryStage) //question: how should we handle close when in server mode
+            }
+        } catch (e: CommandLine.ParameterException) {
+            System.err.println(e.message)
+            commandLine.usage(System.out)
+            Platform.exit()
+        }
     }
 
-    fun setupService() {
-        modelService = DataModelService(eventBus)
-        endpoint = OptimizerEndpoint(modelService, eventBus)
-        server = ServerBuilder
-                .forPort(5550)
-                .addService(ServerInterceptors.intercept(endpoint, LoggingInterceptor(System.out)))
-                .build()
-        server.start()
+    override fun stop() {
+        optimizer.stop()
     }
 }
+
+@Command(name = "Optimizer",
+        mixinStandardHelpOptions = true,
+        version = ["Reference version: 1.0", "Volition API version: 1.0"],
+        description = ["Reference optimizer using Volition API"])
+class Optimizer {
+    private lateinit var optimizerEndpoint: OptimizerEndpoint
+    private lateinit var modelService: DataModelService
+    private lateinit var optimizerService : OptimizerService
+    private lateinit var pluginService : PluginService
+    private lateinit var server: Server
+    private lateinit var apiService: ApiService
+
+    private val eventBus: EventBus = EventBus()
+    private val logger : ConsoleOutput = ConsoleOutput(eventBus)
+
+    @Option(names = ["-l", "--headless"], description = ["Run Optimizer in Headless Mode"])
+    var headless: Boolean = false
+
+    @Option(names = ["-p", "--port"], paramLabel = "PORT", description = ["Run optimizer with specified port, when not specified, port number will default to 5550"])
+    var port: Int = 5550
+
+    @Option(names = ["-o", "--overwrite"], description = ["Enable register overwrite when duplication happens"])
+    var overwrite: Boolean = false
+
+    private fun setup(){
+        modelService = DataModelService(eventBus, overwrite)
+        pluginService = PluginService(modelService, logger, eventBus)
+        optimizerService = OptimizerService(RandomNumberOptimizer(), modelService, eventBus, pluginService)
+        apiService = ApiService(modelService, optimizerService)
+        optimizerEndpoint = OptimizerEndpoint(apiService)
+        server = NettyServerBuilder.forPort(port).addService(ServerInterceptors.intercept(optimizerEndpoint, LoggingInterceptor(logger))).build()
+    }
+
+    fun start(primaryStage: Stage) {
+        setup()
+        try {
+            logger.log("Server started at: localhost:$port", "Optimizer")
+            server.start()
+        } catch (e: IOException) {
+            logger.log("Error encountered when try to start the optimizer server.", "Optimizer")
+            return
+        }
+
+        if(headless){
+            //TODO splash screen etc.
+        }
+        else{
+            val optimizerGUI = OptimizerGUIRootController(modelService, optimizerService, eventBus)
+            primaryStage.title = "Volition Reference Optimizer"
+            primaryStage.scene = Scene(optimizerGUI.root)
+            primaryStage.show()
+        }
+    }
+
+    fun stop() {
+        logger.outChannel.close()
+        server.shutdown()
+    }
+
+}
+
+

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerEndPoint.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerEndPoint.kt
@@ -1,282 +1,98 @@
 package com.empowerops.volition.ref_oasis
 
 import com.empowerops.volition.dto.*
-import com.google.common.eventbus.EventBus
 import io.grpc.stub.StreamObserver
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.selects.select
-import org.funktionale.either.Either
-import java.time.Duration
 
-sealed class EvaluationResult {
-    data class Success(val name: String, val result: Map<String, Double>) : EvaluationResult()
-    data class TimeOut(val name: String) : EvaluationResult()
-    data class Failed(val name: String, val exception: String) : EvaluationResult()
-    data class Error(val name: String, val exception: String) : EvaluationResult()
-}
+class OptimizerEndpoint(private val apiService: IApiService) : OptimizerGrpc.OptimizerImplBase() {
 
-sealed class CancelResult {
-    data class Canceled(val name: String) : CancelResult()
-    data class CancelFailed(val name: String, val exception: String) : CancelResult()
-}
-
-class OptimizerEndpoint(
-        private val modelService: DataModelService,
-        private val eventBus: EventBus
-) : OptimizerGrpc.OptimizerImplBase() {
-    private var state = State.Idle
-
-    enum class State {
-        Idle,
-        Running,
-        Pause
+    override fun changeNodeName(
+            request: NodeNameChangeCommandDTO,
+            responseObserver: StreamObserver<NodeNameChangeResponseDTO>
+    ) = responseObserver.consume {
+        apiService.changeNodeName(request)
     }
 
-    override fun changeNodeName(request: NodeNameChangeCommandDTO, responseObserver: StreamObserver<NodeNameChangeResponseDTO>) = responseObserver.consume {
-        val changed = modelService.renameSim(request.newName, request.oldName)
-        NodeNameChangeResponseDTO.newBuilder().setChanged(changed).build()
+    override fun autoConfigure(
+            request: NodeStatusCommandOrResponseDTO,
+            responseObserver: StreamObserver<NodeChangeConfirmDTO>
+    ) = responseObserver.consume {
+        apiService.autoConfigure(request)
     }
 
-    override fun register(request: RegistrationCommandDTO, responseObserver: StreamObserver<OASISQueryDTO>) {
-        if (modelService.simulations.hasName(request.name)) {
-            responseObserver.onCompleted()
-            return
-        }
-        modelService.addNewSim(Simulation(request.name, emptyList(), emptyList(), "", responseObserver, Channel(RENDEZVOUS), Channel(RENDEZVOUS), Channel(RENDEZVOUS)))
-        eventBus.post(StatusUpdateEvent("${request.name} registered"))
+    override fun updateConfiguration(
+            request: ConfigurationCommandDTO,
+            responseObserver: StreamObserver<ConfigurationResponseDTO>
+    ) = responseObserver.consume {
+        apiService.updateConfiguration(request)
     }
 
-    override fun startOptimization(request: StartOptimizationCommandDTO, responseObserver: StreamObserver<StartOptimizationResponseDTO>) = responseObserver.consume {
-        val issues = modelService.findIssue()
-        val message: String
-
-        if (issues.isNotEmpty()) {
-            message = "Optimization cannot start: ${issues.joinToString(", ")}"
-        } else {
-            message = "Optimization started"
-            GlobalScope.async { startOptimization(RandomNumberOptimizer()) }
-        }
-
-        StartOptimizationResponseDTO.newBuilder().setMessage(message).setStarted(issues.isEmpty()).build()
+    override fun requestRunResult(
+            request: ResultRequestDTO,
+            responseObserver: StreamObserver<ResultResponseDTO>
+    ) = responseObserver.consume {
+        apiService.resultRequest(request)
     }
 
-    suspend fun startOptimization(optimizer: RandomNumberOptimizer) {
-        state = State.Running
-        eventBus.post(StatusUpdateEvent("Evaluating..."))
-        while (state == State.Running) {
-            var pluginNumber = 1
-            for (proxy in modelService.proxies) {
-                eventBus.post(StatusUpdateEvent("Evaluating: ${proxy.name} ($pluginNumber/${modelService.simulations.size})"))
-                val inputVector = optimizer.generateInputs(proxy.inputs)
-                val simResult = evaluate(proxy.name, inputVector)
-                eventBus.post(NewResultEvent(makeResult(simResult, inputVector)))
-                eventBus.post(StatusUpdateEvent("Evaluation finished."))
-                if (simResult is EvaluationResult.TimeOut) {
-                    eventBus.post(StatusUpdateEvent("Timed out, Canceling..."))
-                    cancel(proxy.name)
-                    eventBus.post(StatusUpdateEvent("Cancel finished."))
-                }
-                pluginNumber++
-            }
-            if (state == State.Pause) {
-                eventBus.post(StatusUpdateEvent("Paused"))
-                while (state == State.Pause && state != State.Idle) {
-                    delay(500)
-                }
-            }
-        }
-        eventBus.post(StatusUpdateEvent("Idle"))
+    override fun registerRequest(
+            request: RequestRegistrationCommandDTO,
+            responseObserver: StreamObserver<RequestQueryDTO>
+    ) {
+        apiService.register(request, responseObserver)
     }
 
-    private fun makeResult(evaluationResult: EvaluationResult, inputVector: Map<String, Double>): Result = when (evaluationResult) {
-        is EvaluationResult.Success -> {
-            Result(evaluationResult.name, "Success", inputVector.toString(), evaluationResult.result.toString())
-        }
-        is EvaluationResult.Failed -> {
-            Result(evaluationResult.name, "Failed", inputVector.toString(), "Evaluation Failed: \n${evaluationResult.exception}")
-        }
-        is EvaluationResult.TimeOut -> {
-            Result(evaluationResult.name, "Timeout", inputVector.toString(), "N/A")
-        }
-        is EvaluationResult.Error -> {
-            Result(evaluationResult.name, "Error", inputVector.toString(), "Error:\n${evaluationResult.exception}")
-        }
+    override fun startOptimization(
+            request: StartOptimizationCommandDTO,
+            responseObserver: StreamObserver<StartOptimizationResponseDTO>
+    ) = responseObserver.consumeThen(apiService.issueStartOptimization(request)) { response ->
+        if (response.responseCase == StartOptimizationResponseDTO.ResponseCase.RUNID) apiService.startAsync()
     }
 
-    private suspend fun evaluate(name: String, inputVector: Map<String, Double>): EvaluationResult {
-        val simulation = modelService.simulations.getValue(name)
-        val proxy = modelService.proxies.getValue(name)
-        val message = OASISQueryDTO.newBuilder().setEvaluationRequest(
-                OASISQueryDTO.SimulationEvaluationRequest
-                        .newBuilder()
-                        .setName(name)
-                        .putAllInputVector(inputVector)
-        ).build()
-
-        return try {
-            simulation.input.onNext(message)
-            select {
-                simulation.output.onReceive { EvaluationResult.Success(it.name, it.outputVectorMap) }
-                simulation.error.onReceive { EvaluationResult.Failed(it.name, it.exception) }
-                if (proxy.timeOut != null) {
-                    onTimeout(proxy.timeOut.toMillis()) {
-                        EvaluationResult.TimeOut(name)
-                    }
-                }
-            }
-        } catch (exception: Exception) {
-            EvaluationResult.Error("Optimizer", "Unexpected error happened when try to evaluate $inputVector though simulation $name. Cause: $exception")
-        }
+    override fun stopOptimization(
+            request: StopOptimizationCommandDTO,
+            responseObserver: StreamObserver<StopOptimizationResponseDTO>
+    ) = responseObserver.consumeThen(apiService.issueStopOptimization(request)) { response ->
+        if (response.responseCase == StopOptimizationResponseDTO.ResponseCase.RUNID) apiService.stop()
     }
 
-    fun stopOptimization(): Boolean {
-        state = State.Idle
-        return true
+    override fun updateNode(
+            request: NodeStatusCommandOrResponseDTO,
+            responseObserver: StreamObserver<NodeChangeConfirmDTO>
+    ) = responseObserver.consume {
+        apiService.updateNode(request)
     }
 
-    fun pauseOptimization(): Boolean = when (state) {
-        State.Running -> {
-            state = State.Pause
-            true
-        }
-        State.Pause -> {
-            state = State.Running
-            false
-        }
-        else -> false
+    override fun sendMessage(
+            request: MessageCommandDTO,
+            responseObserver: StreamObserver<MessageResponseDTO>
+    ) = responseObserver.consume {
+        apiService.sendMessage(request)
     }
 
-    suspend fun updateNode(simName: String) {
-        syncConfigFor(simName)
+    override fun unregisterRequest(
+            request: RequestUnRegistrationRequestDTO,
+            responseObserver: StreamObserver<UnRegistrationResponseDTO>
+    ) = responseObserver.consume {
+        apiService.unregister(request)
     }
 
-    suspend fun cancelAll() {
-        modelService.simulations.forEach { cancel(it.name) }
+    override fun offerSimulationResult(
+            request: SimulationResponseDTO,
+            responseObserver: StreamObserver<SimulationResultConfirmDTO>
+    ) = responseObserver.consumeAsync {
+        apiService.offerResult(request)
     }
 
-    /**
-     * Cancel is NOT running in async mode because we are not managing state for plugin and we always assume plugin is in ready state
-     * whenever it returns a result
-     */
-    private suspend fun cancel(name: String) {
-        val message = OASISQueryDTO.newBuilder().setCancelRequest(OASISQueryDTO.SimulationCancelRequest.newBuilder().setName(name)).build()
-        val simulation = modelService.simulations.getValue(name)
-
-        simulation.input.onNext(message)
-        val cancelResult = select<CancelResult> {
-            simulation.output.onReceive { CancelResult.Canceled(it.name) }
-            simulation.error.onReceive { CancelResult.CancelFailed(it.name, it.exception) }
-        }
-        val cancelMessage = when (cancelResult) {
-            is CancelResult.Canceled -> {
-                Message("Optimizer", "Evaluation Canceled")
-            }
-            is CancelResult.CancelFailed -> {
-                Message("Optimizer", "Cancellation Failed, Cause:\n${cancelResult.exception}")
-            }
-        }
-        eventBus.post(NewMessageEvent(cancelMessage))
+    override fun offerErrorResult(
+            request: ErrorResponseDTO,
+            responseObserver: StreamObserver<ErrorConfirmDTO>
+    ) = responseObserver.consumeAsync {
+        apiService.offerError(request)
     }
 
-    suspend fun cancelAndStop() {
-        stopOptimization()
-        cancelAll()
+    override fun offerSimulationConfig(
+            request: NodeStatusCommandOrResponseDTO,
+            responseObserver: StreamObserver<NodeChangeConfirmDTO>
+    ) = responseObserver.consumeAsync {
+        apiService.offerConfig(request)
     }
-
-    private suspend fun syncConfigFor(simName: String) {
-        val sim = modelService.simulations.getValue(simName)
-        val message = OASISQueryDTO.newBuilder().setNodeStatusRequest(
-                OASISQueryDTO.NodeStatusUpdateRequest.newBuilder().setName(simName)
-        ).build()
-        var result: Either<Simulation, Message>
-        try {
-            sim.input.onNext(message)
-
-            result = select {
-                sim.update.onReceive { Either.Left(updateFromResponse(it)) }
-                sim.error.onReceive {
-                    Either.Right(Message(it.name, "Error update simulation $simName due to ${it.message} :\n${it.exception}"))
-                }
-                onTimeout(Duration.ofSeconds(5).toMillis()) {
-                    Either.Right(Message("Optimizer", "Update simulation timeout. Please check simulation is registered and responsive."))
-                }
-            }
-        } catch (exception: Exception) {
-            result = Either.Right(Message("Optimizer", "Unexpected error happened when update simulation $simName failed. Please check simulation is registered and responsive. Cause:\n$exception"))
-        }
-
-        if (result.isLeft()) {
-            modelService.updateSim(result.left().get())
-        } else {
-            eventBus.post(NewMessageEvent(result.right().get()))
-        }
-    }
-
-    override fun stopOptimization(request: StopOptimizationCommandDTO, responseObserver: StreamObserver<StopOptimizationResponseDTO>) = responseObserver.consume {
-        GlobalScope.async { stopOptimization() }
-        StopOptimizationResponseDTO.newBuilder().setMessage("Stop acknowledged").setStopped(true).build()
-    }
-
-    override fun offerSimulationResult(request: SimulationResponseDTO, responseObserver: StreamObserver<SimulationResultConfirmDTO>) = responseObserver.consume {
-        val output = modelService.simulations.getNamed(request.name)?.output
-        if (output != null) {
-            output.send(request)
-        } else {
-            throw IllegalStateException("no simulation '${request.name}' or buffer full")
-        }
-        SimulationResultConfirmDTO.newBuilder().build()
-    }
-
-    override fun offerErrorResult(request: ErrorResponseDTO, responseObserver: StreamObserver<ErrorConfirmDTO>) = responseObserver.consume {
-        val error = modelService.simulations.getNamed(request.name)?.error
-        if (error != null) {
-            error.send(request)
-        } else {
-            throw IllegalStateException("no simulation '${request.name}' or buffer full")
-        }
-        ErrorConfirmDTO.newBuilder().build()
-    }
-
-    override fun offerSimulationConfig(request: NodeStatusCommandOrResponseDTO, responseObserver: StreamObserver<NodeChangeConfirmDTO>) = responseObserver.consume {
-        val update = modelService.simulations.getNamed(request.name)?.update
-
-        if (update != null) {
-            update.send(request)
-        } else {
-            throw IllegalStateException("no simulation '${request.name}' or buffer full")
-        }
-        NodeChangeConfirmDTO.newBuilder().build()
-    }
-
-    override fun updateNode(request: NodeStatusCommandOrResponseDTO, responseObserver: StreamObserver<NodeChangeConfirmDTO>) = responseObserver.consume {
-        val newNode = updateFromResponse(request)
-        modelService.updateSim(newNode)
-        eventBus.post(StatusUpdateEvent("${request.name} updated"))
-        NodeChangeConfirmDTO.newBuilder().setMessage("Simulation updated with inputs: ${newNode.inputs} outputs: ${newNode.outputs}").build()
-    }
-
-
-    override fun sendMessage(request: MessageCommandDTO, responseObserver: StreamObserver<MessageReponseDTO>) = responseObserver.consume {
-        eventBus.post(NewMessageEvent(Message(request.name, request.message)))
-        MessageReponseDTO.newBuilder().build()
-    }
-
-    override fun unregister(request: UnRegistrationRequestDTO, responseObserver: StreamObserver<UnRegistrationResponseDTO>) = responseObserver.consume {
-        val unregistered = modelService.closeSim(request.name)
-        UnRegistrationResponseDTO.newBuilder().setUnregistered(unregistered).build()
-    }
-
-    private fun updateFromResponse(request: NodeStatusCommandOrResponseDTO): Simulation {
-        return modelService.simulations.single { it.name == request.name }.copy(
-                name = request.name,
-                inputs = request.inputsList.map { Input(it.name, it.lowerBound, it.upperBound, it.currentValue) },
-                outputs = request.outputsList.map { Output(it.name) },
-                description = request.description
-        )
-    }
-
 }

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerGUIRootController.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerGUIRootController.kt
@@ -1,0 +1,18 @@
+package com.empowerops.volition.ref_oasis
+
+import com.google.common.eventbus.EventBus
+import javafx.fxml.FXMLLoader
+import javafx.scene.Parent
+
+class OptimizerGUIRootController (modelService: DataModelService, optimizerService: OptimizerService, eventBus: EventBus){
+    val root : Parent
+    init {
+        val fxmlLoader = FXMLLoader()
+        val resourceAsStream = this.javaClass.classLoader.getResourceAsStream("com.empowerops.volition.ref_oasis/OptimizerView.fxml")
+        root = fxmlLoader.load<Parent>(resourceAsStream)
+
+        val controller = fxmlLoader.getController<OptimizerController>()
+        val connectionView = ConnectionView(modelService, eventBus)
+        controller.attachToModel(modelService, eventBus, connectionView.root, optimizerService)
+    }
+}

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerService.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerService.kt
@@ -1,0 +1,131 @@
+package com.empowerops.volition.ref_oasis
+
+import com.empowerops.volition.ref_oasis.State.*
+import com.google.common.eventbus.EventBus
+import kotlinx.coroutines.*
+import kotlinx.coroutines.selects.select
+import org.funktionale.either.Either
+import java.util.*
+import kotlin.collections.HashMap
+
+class OptimizerService(
+        private val optimizer: RandomNumberOptimizer,
+        private val modelService: DataModelService,
+        private val eventBus: EventBus,
+        private val pluginEndpoint: PluginService) {
+    var state = OptimizerStateMachine()
+        private set
+    private var currentlyEvaluatedProxy: Proxy? = null  // This is for testing action on cancel current
+    private var resumed: CompletableDeferred<Unit>? = null
+
+    private var currentRunID: UUID? = null
+
+    fun canStop(): Boolean {
+        return (currentRunID != null) && state.canTransferTo(StopPending)
+    }
+
+    fun stopOptimization() {
+        require(canStop()) { "Illegal state to stop" }
+        state.transferTo(StopPending)
+        resumed?.complete(Unit)
+        eventBus.post(StopRequestedEvent())
+    }
+
+    fun forceStop(): Boolean {
+        val stopResult = state.transferTo(Idle)
+        if (stopResult) eventBus.post(ForceStopRequestedEvent())
+        pluginEndpoint.forceStopAll()
+        return stopResult
+    }
+
+    fun pauseOptimization(): Boolean {
+        val transferResult = state.transferTo(PausePending)
+        if (transferResult) eventBus.post(PausedRequestedEvent())
+        return transferResult
+    }
+
+    fun resumeOptimization(): Boolean {
+        val transferResult = state.transferTo(Running)
+        resumed!!.complete(Unit)
+        if (transferResult) eventBus.post(RunResumedEvent())
+        return transferResult
+    }
+
+    /**
+     * This is a debugging feature
+     */
+    suspend fun cancelCurrent() {
+        val proxy = currentlyEvaluatedProxy
+        if (proxy != null) {
+            pluginEndpoint.cancelCurrentEvaluation(proxy)
+        }
+    }
+
+    /**
+     * This is a debugging feature
+     */
+    suspend fun cancelStop() {
+        stopOptimization()
+        cancelCurrent()
+    }
+
+    fun requestStart(): Either<List<String>, UUID> {
+        var issues = modelService.findIssue()
+        if (!state.canTransferTo(StartPending)) {
+            issues += "Optimization is not ready to start: current state ${state.currentState}"
+        }
+        if (issues.isEmpty()) {
+            currentRunID = UUID.randomUUID()
+            return Either.right(currentRunID!!)
+        } else {
+            return Either.left(issues)
+        }
+    }
+
+    suspend fun startOptimization() {
+        require(currentRunID != null && modelService.findIssue().isEmpty() && state.canTransferTo(StartPending))
+        state.transferTo(StartPending)
+        eventBus.post(StartRequestedEvent())
+
+        try {
+            state.transferTo(Running)
+            eventBus.post(RunStartedEvent(currentRunID!!))
+            pluginEndpoint.notifyStart(currentRunID!!)
+            while (state.currentState == Running) {
+                var pluginNumber = 1
+                for (proxy in modelService.proxies) {
+                    eventBus.post(StatusUpdateEvent("Evaluating: ${proxy.name} ($pluginNumber/${modelService.proxies.size})"))
+                    val inputVector = optimizer.generateInputs(proxy.inputs)
+                    evaluate(inputVector, proxy, currentRunID!!)
+                    pluginNumber++
+                }
+                if (state.currentState == PausePending) {
+                    state.transferTo(Paused)
+                    eventBus.post(PausedEvent(currentRunID!!))
+                    resumed = CompletableDeferred()
+                    select<Unit> {
+                        resumed!!.onAwait { Unit }
+                    }
+                }
+            }
+        } finally {
+            state.transferTo(Idle)
+            eventBus.post(RunStoppedEvent(currentRunID!!))
+            pluginEndpoint.notifyStop(currentRunID!!)
+        }
+    }
+
+    private suspend fun evaluate(inputVector: Map<String, Double>, proxy: Proxy, runID: UUID) {
+        currentlyEvaluatedProxy = proxy
+        val simResult = pluginEndpoint.evaluate(proxy, inputVector)
+        currentlyEvaluatedProxy = null
+        modelService.addNewResult(runID, simResult)
+        eventBus.post(StatusUpdateEvent("Evaluation finished."))
+        if (simResult is EvaluationResult.TimeOut) {
+            eventBus.post(StatusUpdateEvent("Timed out, Canceling..."))
+            pluginEndpoint.cancelCurrentEvaluation(proxy)
+            eventBus.post(StatusUpdateEvent("Cancel finished."))
+        }
+    }
+
+}

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerStateMachine.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/OptimizerStateMachine.kt
@@ -1,0 +1,35 @@
+package com.empowerops.volition.ref_oasis
+
+import com.empowerops.volition.ref_oasis.State.*
+
+enum class State {
+    Idle,
+    StartPending,
+    Running,
+    PausePending,
+    Paused,
+    StopPending
+}
+
+class OptimizerStateMachine {
+    var currentState: State = Idle
+    private val stateTable: Map<State, List<State>> = mapOf(
+            Idle to listOf(StartPending),
+            StartPending to listOf(Running, Idle),
+            Running to listOf(PausePending, StopPending),
+            PausePending to listOf(Paused, StopPending),
+            Paused to listOf(Running, StopPending),
+            StopPending to listOf(Idle)
+    )
+
+    fun transferTo(newState: State): Boolean = if (newState in stateTable.getValue(currentState)) {
+        currentState = newState
+        true
+    } else {
+        //do log
+        false
+    }
+
+    fun canTransferTo(newState: State) : Boolean = newState in stateTable.getValue(currentState)
+
+}

--- a/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/PluginService.kt
+++ b/oasis-reference/src/main/kotlin/com/empowerops/volition/ref_oasis/PluginService.kt
@@ -1,0 +1,170 @@
+package com.empowerops.volition.ref_oasis
+
+import com.empowerops.volition.dto.NodeStatusCommandOrResponseDTO
+import com.empowerops.volition.dto.RequestQueryDTO
+import com.google.common.eventbus.EventBus
+import com.google.common.eventbus.Subscribe
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import org.funktionale.either.Either
+import java.time.Duration
+import java.util.*
+
+class PluginService(
+        private val modelService : DataModelService,
+        private val logger: ConsoleOutput,
+        private val eventBus: EventBus
+){
+    init {
+        eventBus.register(this)
+    }
+
+    private var sessionForceStopSignals : List<ForceStopSignal> = emptyList()
+
+    @Subscribe
+    fun onUpdateNodeRequested(event : SimulationUpdateRequestedEvent) = GlobalScope.launch{
+        val sim = modelService.simulations.getValue(event.name)
+        val message = RequestQueryDTO.newBuilder().setNodeStatusRequest(
+                RequestQueryDTO.NodeStatusUpdateRequest.newBuilder().setName(event.name)
+        ).build()
+        var result: Either<Simulation, Message>
+        try {
+            sim.input.onNext(message)
+
+            result = select {
+                sim.update.onReceive { Either.Left(updateFromResponse(it)) }
+                sim.error.onReceive {
+                    Either.Right(Message(it.name, "Error update simulation ${event.name} due to ${it.message} :\n${it.exception}"))
+                }
+                this.onTimeout(Duration.ofSeconds(5).toMillis()) {
+                    Either.Right(Message("Optimizer", "Update simulation timeout. Please check simulation is registered and responsive."))
+                }
+            }
+        } catch (exception: Exception) {
+            result = Either.Right(Message("Optimizer", "Unexpected error happened when update simulation ${event.name} failed. Please check simulation is registered and responsive. Cause:\n$exception"))
+        }
+        if (result.isLeft()) {
+            modelService.updateSimAndConfiguration(result.left().get())
+        }
+        else {
+            val resultMessage = result.right().get()
+            logger.log(resultMessage.message, resultMessage.sender)
+        }
+    }
+
+    /**
+     * Notify each simulation a new run has started with RunID and they should record the runID
+     * if they need retrieve this run result.
+     *
+     * Simulation can also ignore this message
+     */
+    fun notifyStart(runId : UUID) {
+        for(proxy in modelService.proxies){
+            val runStartQueryDTO = RequestQueryDTO.newBuilder().setStartRequest(
+                    RequestQueryDTO.SimulationStartedRequest.newBuilder().setRunID(runId.toString())
+            ).build()
+
+            try{
+                modelService.simulations.getValue(proxy.name).input.onNext(runStartQueryDTO)
+            }
+            catch (exception: Exception) {
+                logger.log("Error sending start request to ${proxy.name}", "Optimizer")
+            }
+        }
+    }
+
+    /**
+     * Notify each simulation the current run has stopped and they should record the runID
+     * if they need retrieve that run result later.
+     *
+     * Simulation can also ignore this message
+     */
+    fun notifyStop(runId : UUID) {
+        for(proxy in modelService.proxies){
+            val runStopQueryDTO = RequestQueryDTO.newBuilder().setStopRequest(
+                    RequestQueryDTO.SimulationStoppedRequest.newBuilder().setRunID(runId.toString())
+            ).build()
+
+            try{
+                modelService.simulations.getValue(proxy.name).input.onNext(runStopQueryDTO)
+            }
+            catch (exception : Exception){
+                logger.log("Error sending stop request to ${proxy.name}", "Optimizer")
+            }
+        }
+    }
+
+    suspend fun evaluate(proxy: Proxy, inputVector: Map<String, Double>): EvaluationResult {
+        val simulation = modelService.simulations.getValue(proxy.name)
+        val message = RequestQueryDTO.newBuilder().setEvaluationRequest(
+                RequestQueryDTO.SimulationEvaluationRequest
+                        .newBuilder()
+                        .setName(simulation.name)
+                        .putAllInputVector(inputVector)
+        ).build()
+        val forceStopSignal = ForceStopSignal(proxy.name)
+        sessionForceStopSignals += forceStopSignal
+        return try {
+            simulation.input.onNext(message)
+            select {
+                simulation.output.onReceive { EvaluationResult.Success(it.name, inputVector, it.outputVectorMap) }
+                simulation.error.onReceive { EvaluationResult.Failed(it.name, inputVector, it.exception) }
+                if (proxy.timeOut != null) {
+                    onTimeout(proxy.timeOut.toMillis()) {
+                        EvaluationResult.TimeOut(simulation.name, inputVector)
+                    }
+                }
+                forceStopSignal.completableDeferred.onAwait{
+                    EvaluationResult.Terminated(simulation.name, inputVector, "Evaluation is terminated")
+                }
+            }
+        } catch (exception: Exception) {
+            EvaluationResult.Error(
+                    "Optimizer",
+                    inputVector,
+                    "Unexpected error happened when try to evaluate $inputVector though simulation ${simulation.name}. Cause: $exception"
+            )
+        } finally {
+            sessionForceStopSignals -= forceStopSignal
+        }
+    }
+
+    /**
+     * Cancel is NOT running in async mode because we are not managing state for plugin and we always assume plugin is in ready state
+     * whenever it returns a result
+     */
+    suspend fun cancelCurrentEvaluation(proxy: Proxy) {
+        val simulation = modelService.simulations.getValue(proxy.name)
+        val message = RequestQueryDTO.newBuilder().setCancelRequest(RequestQueryDTO.SimulationCancelRequest.newBuilder().setName(simulation.name)).build()
+
+        simulation.input.onNext(message)
+        val cancelResult = select<CancelResult> {
+            simulation.output.onReceive { CancelResult.Canceled(it.name) }
+            simulation.error.onReceive { CancelResult.CancelFailed(it.name, it.exception) }
+
+        }
+        val cancelMessage = when (cancelResult) {
+            is CancelResult.Canceled -> {
+                "Evaluation Canceled"
+            }
+            is CancelResult.CancelFailed -> {
+                "Cancellation Failed, Cause:\n${cancelResult.exception}"
+            }
+        }
+        logger.log(cancelMessage, "Optimizer")
+    }
+
+    fun forceStopAll(){
+        sessionForceStopSignals.forEach{ it.completableDeferred.complete(Unit) }
+    }
+
+    private fun updateFromResponse(request: NodeStatusCommandOrResponseDTO): Simulation {
+        return modelService.simulations.single { it.name == request.name }.copy(
+                name = request.name,
+                inputs = request.inputsList.map { Input(it.name, it.lowerBound, it.upperBound, it.currentValue) },
+                outputs = request.outputsList.map { Output(it.name) },
+                description = request.description
+        )
+    }
+}

--- a/oasis-reference/src/main/resources/com.empowerops.volition.ref_oasis/OptimizerView.fxml
+++ b/oasis-reference/src/main/resources/com.empowerops.volition.ref_oasis/OptimizerView.fxml
@@ -129,12 +129,10 @@
                                 <rowConstraints>
                                     <RowConstraints vgrow="NEVER" />
                                     <RowConstraints vgrow="NEVER" />
-                                    <RowConstraints vgrow="NEVER" />
                                 </rowConstraints>
                                 <Label text="Optimization" />
-                                <Button mnemonicParsing="false" onAction="#stopRun" text="Stop" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                                <Button mnemonicParsing="false" onAction="#startRun" text="Start" GridPane.columnIndex="1" />
-                                <Button fx:id="pauseButton" mnemonicParsing="false" onAction="#pauseRun" text="Pause" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                                <Button fx:id="startButton" mnemonicParsing="false" onAction="#startStopClicked" text="Start" GridPane.columnIndex="1" />
+                                <Button fx:id="pauseButton" mnemonicParsing="false" onAction="#pauseResumeRun" text="Pause" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                             </GridPane>
                         </VBox>
                         <VBox>


### PR DESCRIPTION
This is a PR for #12 

- add the issues return on start, showing as pop up
- add the result return on stop, showing as message
- add auto configuration setup, with new button in plugin, change the old button and function as update. The old update call can be used as a invalidation method to update.
- change the message and result as part of the model, which used to be view only concept
- update eventing between UI and module service, and ui changes only react to event. i.e. 1.Click a button -> 2.button action call service -> 3.service do business logic and post a event base on the result-> UI changes base on the event. Also the old(bad) way is: 1.Click a button -> 2.View changes its state base on the action and call service to do business logic
- add configuration setup to API, currently only support modifying timeout, which is also the only thing we got other than ranges. However to fully support headless mode with full control, a more granular set of call will be needed to be able to operate on `DataModelService`. Also, we are missing the concept of run option right now, which means it is not yet fully automatic after click on start. 
- add result retrieve using the run ID, result is send back via repeated field. No project saving and excel export considered in this version.
- formalize the state machine for reference, the goal of this is decouple UI and service. We used to combine a lot of UI state and service state in the UI. Which means a non ui action, like plugin click on start on optimization will not change the UI state. Now everything moved to service and UI are respecting update event. 
- add concept of run with runID, this is optional to user of API. This make it possible to tracking/retrieving result with only client side command. Optimal finding is not yet available in the reference optimizer yet. 
- move the optimizer related call out of the endpoint to optimizer service, move the client side call into PluginEndpoint. The OptimizerEndpoint is now purely imprlenation of the interface. I think this make our business logic more conposlabe and reusable when we port it and as we moving on adding more features. 
- add headless mode, use `-l` or `-headless` for headless mode when running in command line. 
- add custom port number, use `-p=port number` or `-port=portnumber` for custom port setup in command line
- add stdout 'Logging'. API call will be logged and the rest are logged though (typed) event posting.

This also starting on issue #16 and #17 with added result retrieve and run ID and update the server to use NettyServer. 