### PR TITLE
Use Vcpkg's built-in integration with GitHub Actions cache for C++

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -32,19 +32,17 @@ jobs:
       id: strings
       shell: bash
       run: |
-        SOURCE_PATH="${{ github.workspace }}/cpp-client-reference";
-        VCPKG_ARCHIVE_PATH="$SOURCE_PATH/vcpkg_archives";
         cat << EOF >> "$GITHUB_OUTPUT"
-        source-path=$SOURCE_PATH
-        vcpkg-archive-path=$VCPKG_ARCHIVE_PATH
+        source-path=${{ github.workspace }}/cpp-client-reference
         EOF
 
     - name: Set environment variables
-      shell: bash
-      run: |
-        cat << EOF >> "$GITHUB_ENV"
-        VCPKG_BINARY_SOURCES=files,${{ steps.strings.outputs.vcpkg-archive-path }},readwrite
-        EOF
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable("ACTIONS_CACHE_URL", process.env.ACTIONS_CACHE_URL || "");
+          core.exportVariable("ACTIONS_RUNTIME_TOKEN", process.env.ACTIONS_RUNTIME_TOKEN || "");
+          core.exportVariable("VCPKG_BINARY_SOURCES", "clear;x-gha,readwrite")
 
     - name: List environment variables
       run: env
@@ -52,13 +50,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-
-    - name: Cache Vcpkg archives
-      id: cache-vcpkg-archives
-      uses: actions/cache@v3
-      with:
-        key: ${{ matrix.preset }}
-        path: "${{ steps.strings.outputs.vcpkg-archive-path }}"
 
     - name: Configure CMake
       run: >

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -28,13 +28,9 @@ jobs:
             build_type: Release
 
     steps:
-    - name: Set reusable strings
-      id: strings
-      shell: bash
-      run: |
-        cat << EOF >> "$GITHUB_OUTPUT"
-        source-path=${{ github.workspace }}/cpp-client-reference
-        EOF
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Set environment variables
       uses: actions/github-script@v7
@@ -42,14 +38,15 @@ jobs:
         script: |
           core.exportVariable("ACTIONS_CACHE_URL", process.env.ACTIONS_CACHE_URL || "");
           core.exportVariable("ACTIONS_RUNTIME_TOKEN", process.env.ACTIONS_RUNTIME_TOKEN || "");
-          core.exportVariable("VCPKG_BINARY_SOURCES", "clear;x-gha,readwrite")
+          core.exportVariable("VCPKG_BINARY_SOURCES", "clear;x-gha,readwrite");
 
-    - name: List environment variables
-      run: env
-
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        cat << EOF >> "$GITHUB_OUTPUT"
+        source-path=${{ github.workspace }}/cpp-client-reference
+        EOF
 
     - name: Configure CMake
       run: >

--- a/cpp-client-reference/README.md
+++ b/cpp-client-reference/README.md
@@ -1,5 +1,7 @@
 # C++ Volition API
 
+[![C++](https://github.com/EmpowerOperations/volition/actions/workflows/cpp.yml/badge.svg)](https://github.com/EmpowerOperations/volition/actions/workflows/cpp.yml)
+
 This is a simple CMake project to help you get started with building the Volition Client API for your C++ Application. This CMake project will use vcpkg to pull the necessary GRPC dependencies, use `protoc` with `optimizer.proto` to generate the necessary client-side code, and use the `Source.cpp` C++ reference client application to build a stub CPP application that demonstrates an Optimization with the Volition C++ API.
 
 ## Dependencies


### PR DESCRIPTION
In the current C++ workflow, GitHub Actions cache (1) is keyed by preset name and (2) stores the entire Vcpkg archive directory.

Problem 1: Keying by preset name alone can cause false positive cache hits due to the lack of a commit ID or equivalent content hash key. Vcpkg will still build the dependencies correctly as it does its own hash computation and will rebuild packages when necessary. But the build will not fully benefit from caching.

Problem 2: A whole archive cache does not provide enough granularity, resulting in lower cache hit rates. Also, ABI compatible build artifacts produced by toolchains such as GCC and Clang cannot be shared.

## Changes

This PR update the C++ GitHub Actions workflow to use Vcpkg's built-in integration (experimental) with [GitHub Actions cache](https://learn.microsoft.com/en-ca/vcpkg/users/binarycaching#gha). This populates GHA cache with per-package cache entries. Vcpkg handles the hashing. So the workflow code becomes simpler, and the caching mechanism is more reliable.