### PR TITLE
C API design for Volition

### DIFF
--- a/cpp-client-reference/CMakeLists.txt
+++ b/cpp-client-reference/CMakeLists.txt
@@ -9,7 +9,11 @@ project(volition)
 find_package(gRPC CONFIG REQUIRED)
 find_package(Protobuf REQUIRED)
 
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_library(optimizer-proto optimizer.proto)
+set_target_properties(optimizer-proto PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 # Include the generated header files
 target_include_directories(optimizer-proto INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(optimizer-proto PUBLIC gRPC::grpc++)
@@ -24,3 +28,29 @@ protobuf_generate(
 
 add_executable(cpp-client-reference Source.cpp)
 target_link_libraries(cpp-client-reference PRIVATE optimizer-proto)
+
+add_library(volition SHARED
+    src/volition_shim.cpp)
+set_target_properties(volition PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD 20)
+target_include_directories(volition PUBLIC include)
+target_link_libraries(volition PRIVATE optimizer-proto)
+
+add_executable(test_c99 test/test_c99.c)
+set_target_properties(test_c99 PROPERTIES
+    C_EXTENSIONS OFF
+    C_STANDARD 99)
+target_link_libraries(test_c99 PRIVATE volition)
+
+add_executable(test_cxx98 test/test_cxx98.cpp)
+set_target_properties(test_cxx98 PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD 98)
+target_link_libraries(test_cxx98 PRIVATE volition)
+
+add_executable(test_cxx11 test/test_cxx11.cpp)
+set_target_properties(test_cxx11 PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD 11)
+target_link_libraries(test_cxx11 PRIVATE volition)

--- a/cpp-client-reference/include/volition.h
+++ b/cpp-client-reference/include/volition.h
@@ -1,0 +1,223 @@
+#pragma once
+#ifndef VOLITION_H
+#define VOLITION_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#define VL_NULL_HANDLE nullptr
+#define VLAPI_NOEXCEPT noexcept
+#else
+#define VL_NULL_HANDLE NULL
+#define VLAPI_NOEXCEPT throw()
+#endif
+#else
+#define VL_NULL_HANDLE NULL
+#define VLAPI_NOEXCEPT
+#endif
+
+#ifdef _WIN32
+#define VLAPI_PUBLIC __declspec(dllexport)
+#elif __GNUC__ >= 4
+#define VLAPI_PUBLIC __attribute__((visibility("default")))
+#else
+#define VLAPI_PUBLIC
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Handle types.
+typedef struct vl_evaluable_s* vl_evaluable;
+typedef struct vl_event_stream_s* vl_event_stream;
+typedef struct vl_input_s* vl_input;
+typedef struct vl_optimizer_s* vl_optimizer;
+typedef struct vl_result_stream_s* vl_result_stream;
+
+// Data types.
+typedef enum vl_status {
+    // Success codes.
+    VL_SUCCESS = 0,
+    VL_TIMEOUT = 1,
+    VL_STREAM_FINISHED = 2,
+    // Error codes.
+    VL_ERROR_CONNECT_FAILED = -1,
+} vl_status;
+
+typedef struct vl_duration {
+    int64_t seconds;
+    int32_t nanos;
+} vl_duration;
+
+typedef uint8_t vl_uuid[16];
+
+typedef struct vl_evaluation_token {
+    char const* const client;
+    uint32_t const iteration_index;
+} vl_evaluation_token;
+
+typedef struct vl_completion_token {
+    vl_uuid const uuid;
+} vl_completion_token;
+
+typedef struct vl_optimization_settings {
+    vl_duration run_time;
+    double target_objective_value;
+    uint32_t concurrent_run_count;
+    uint32_t iteration_count;
+} vl_optimization_settings;
+
+typedef struct vl_problem_definition {
+    vl_input const* inputs;
+    size_t input_count;
+    vl_evaluable const* evaluables;
+    size_t evaluable_count;
+} vl_problem_definition;
+
+typedef struct vl_evaluation_result {
+    double const* output;
+    bool stop_optimization;
+} vl_evaluation_result;
+
+typedef struct vl_evaluation_status {
+    char const* message;
+} vl_evaluation_status;
+
+typedef struct vl_evaluation_error {
+    char const* message;
+    char const* stacktrace;
+    bool stop_optimization;
+} vl_evaluation_error;
+
+typedef struct vl_client_input {
+    char const* name;
+    char const* client_name; // Set to `NULL` to use the same name.
+} vl_client_input;
+
+typedef struct vl_client_output {
+    char const* name;
+    char const* client_name; // Set to `NULL` to use the same name.
+    bool is_bool;
+} vl_client_output;
+
+typedef struct vl_design_point {
+    double const* input;
+    double const* output;
+    bool is_feasible;
+    bool is_frontier;
+} vl_design_point;
+
+typedef struct vl_seed_point {
+    double const* input;
+    double const* output;
+} vl_seed_point;
+
+// - `user_data`: Data supplied by the user.
+// - `token`: Single-use token that identifies the design iteration in progress. It is used for
+// sending the evaluation result/status/error back to the optimizer.
+// - `input`: Vector of input values. Its lifetime ends when this callback returns. The user is
+// expected to copy `input` to memory they own if the values are needed later (e.g. when the results
+// are evaluated asynchronously).
+typedef void (*vl_evaluation_request_callback)(
+    void* user_data,
+    vl_evaluation_token token,
+    double const* input);
+
+typedef void (*vl_evaluation_cancel_callback)(void* user_data, vl_evaluation_token token);
+
+typedef void (*vl_design_iteration_complete_callback)(void* user_data);
+
+typedef void (*vl_optimization_abort_callback)(void* user_data);
+
+typedef void (*vl_optimization_complete_callback)(void* user_data, vl_completion_token token);
+
+typedef struct vl_event_callbacks {
+    void* user_data;
+    vl_evaluation_request_callback on_evaluation_request;
+    vl_evaluation_cancel_callback on_evaluation_cancel;
+    vl_design_iteration_complete_callback on_design_iteration_complete;
+    vl_optimization_abort_callback on_optimization_abort;
+    vl_optimization_complete_callback on_optimization_complete;
+} vl_event_callbacks;
+
+typedef void (*vl_result_callback)(void* user_data, vl_design_point const* point);
+
+// Service API.
+VLAPI_PUBLIC vl_optimizer vl_create_optimizer(char const* connection, vl_status* status)
+    VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC void vl_destroy_optimizer(vl_optimizer optimizer) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_input
+vl_create_continuous_input(char const* name, double lower_bound, double upper_bound) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_input
+vl_create_step_input(char const* name, double lower_bound, double upper_bound, double step_size)
+    VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_input
+vl_create_discrete_input(char const* name, double const* values, size_t value_count) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC void vl_destroy_input(vl_input input) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_evaluable
+vl_create_babel_constraint_evaluable(char const* output_name, char const* expr) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_evaluable
+vl_create_babel_scalar_evaluable(char const* output_name, char const* expr) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_evaluable vl_create_client_simulation_evaluable(
+    char const* name,
+    vl_client_input const* inputs,
+    size_t input_count,
+    vl_client_output const* outputs,
+    size_t output_count,
+    vl_duration timeout) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC void vl_destroy_evaluable(vl_evaluable evaluable) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_event_stream vl_create_event_stream(
+    vl_optimizer optimizer,
+    vl_optimization_settings const* settings,
+    vl_problem_definition const* problem_definition,
+    vl_seed_point const* seed_points,
+    size_t point_count,
+    vl_status* status) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC void vl_destroy_event_stream(vl_event_stream events) VLAPI_NOEXCEPT;
+
+// May propagate exceptions from callbacks.
+VLAPI_PUBLIC vl_status vl_wait_event(vl_event_stream event_stream, vl_event_callbacks* callbacks);
+
+VLAPI_PUBLIC vl_status vl_stop_optimization(vl_event_stream events) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_status vl_send_evaluation_result(
+    vl_evaluation_token token,
+    vl_evaluation_result const* result) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_status vl_send_evaluation_status(
+    vl_evaluation_token token,
+    vl_evaluation_status const* status) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_status vl_send_evaluation_error(
+    vl_evaluation_token token,
+    vl_evaluation_error const* error) VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC vl_result_stream vl_create_result_stream(vl_completion_token token, vl_status* status)
+    VLAPI_NOEXCEPT;
+
+VLAPI_PUBLIC void vl_destroy_result_stream(vl_result_stream) VLAPI_NOEXCEPT;
+
+// May propagate exceptions from callbacks.
+VLAPI_PUBLIC vl_status
+vl_wait_result(vl_result_stream results, void* user_data, vl_result_callback on_result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // VOLITION_H

--- a/cpp-client-reference/src/volition_shim.cpp
+++ b/cpp-client-reference/src/volition_shim.cpp
@@ -1,0 +1,68 @@
+#include "volition.h"
+
+struct vl_optimizer_s {};
+
+vl_optimizer vl_create_optimizer(char const* connection, vl_status* status) noexcept {
+    return nullptr;
+}
+
+void vl_destroy_optimizer(vl_optimizer optimizer) noexcept {}
+
+vl_input
+vl_create_continuous_input(char const* name, double lower_bound, double upper_bound) noexcept {
+    return nullptr;
+}
+
+vl_input vl_create_step_input(
+    char const* name,
+    double lower_bound,
+    double upper_bound,
+    double step_size) noexcept {
+    return nullptr;
+}
+
+vl_evaluable vl_create_babel_constraint_evaluable(
+    char const* output_name,
+    char const* expr) noexcept {
+    return nullptr;
+}
+
+vl_evaluable vl_create_babel_scalar_evaluable(char const* output_name, char const* expr) noexcept {
+    return nullptr;
+}
+
+vl_evaluable vl_create_client_simulation_evaluable(
+    char const* name,
+    vl_client_input const* inputs,
+    size_t input_count,
+    vl_client_output const* outputs,
+    size_t output_count,
+    vl_duration timeout) noexcept {
+    return nullptr;
+}
+
+struct vl_event_stream_s {};
+
+vl_event_stream vl_create_event_stream(
+    vl_optimizer optimizer,
+    vl_optimization_settings const* settings,
+    vl_problem_definition const* problem_definition,
+    vl_seed_point const* seed_points,
+    size_t point_count,
+    vl_status* status) noexcept {
+    return nullptr;
+}
+
+void vl_destroy_event_stream(vl_event_stream event_stream) noexcept {}
+
+vl_status vl_wait_event(vl_event_stream event_stream, vl_event_callbacks* callbacks) {
+    return VL_SUCCESS;
+}
+
+vl_status vl_stop_optimization(vl_event_stream events) noexcept { return VL_SUCCESS; }
+
+vl_status vl_send_evaluation_result(
+    vl_evaluation_token token,
+    vl_evaluation_result const* result) noexcept {
+    return VL_SUCCESS;
+}

--- a/cpp-client-reference/test/test_c99.c
+++ b/cpp-client-reference/test/test_c99.c
@@ -1,0 +1,72 @@
+#include "volition.h"
+
+#include <math.h>
+#include <stdio.h>
+
+#define COUNT(arr) (sizeof(arr) / sizeof(arr[0]))
+
+typedef struct {
+    double last_value;
+} simulation_state;
+
+void on_evaluation_request(void* user_data, vl_evaluation_token token, double const* input) {
+    simulation_state* state = (simulation_state*)user_data;
+    double const x1 = input[0];
+    vl_evaluation_result const result = {
+        .output = (double[]){x1 * x1 * state->last_value},
+    };
+    vl_send_evaluation_result(token, &result);
+    state->last_value -= 0.1;
+}
+
+void on_optimization_complete(void* user_data, vl_completion_token token) {
+    printf("optimization complete.\n");
+}
+
+int main() {
+    vl_optimizer const optimizer = vl_create_optimizer("localhost:27016", NULL);
+    if (!optimizer) return -1;
+    vl_optimization_settings const settings = {
+        .target_objective_value = -INFINITY,
+        .concurrent_run_count = 2,
+        .iteration_count = 5,
+    };
+    vl_input const inputs[] = {vl_create_continuous_input("x1", 0.5, 5.0)};
+    vl_client_input const sim_inputs[] = {{.name = "x1", .client_name = "x1"}};
+    vl_client_output const sim_outputs[] = {{.name = "f1", .client_name = "f1", .is_bool = false}};
+    vl_evaluable const evaluables[] = {vl_create_client_simulation_evaluable(
+        "test",
+        sim_inputs,
+        COUNT(sim_inputs),
+        sim_outputs,
+        COUNT(sim_outputs),
+        (vl_duration){.seconds = 0})};
+    vl_problem_definition const problem = {
+        .inputs = inputs,
+        .input_count = COUNT(inputs),
+        .evaluables = evaluables,
+        .evaluable_count = COUNT(evaluables),
+    };
+    vl_seed_point seed_points[] = {
+        {.input = (double[]){0.6}, .output = (double[]){42.0}},
+        {.input = (double[]){0.7}, .output = (double[]){42.0}},
+    };
+    vl_event_stream const event_stream = vl_create_event_stream(
+        optimizer, &settings, &problem, seed_points, COUNT(seed_points), NULL);
+    if (!event_stream) return -2;
+    simulation_state state = {
+        .last_value = 42.0,
+    };
+    vl_event_callbacks callbacks = {
+        .user_data = &state,
+        .on_evaluation_request = on_evaluation_request,
+        .on_optimization_complete = on_optimization_complete,
+    };
+    vl_status status;
+    while (!(status = vl_wait_event(event_stream, &callbacks))) {}
+    if (status != VL_STREAM_FINISHED) return -3;
+
+    vl_destroy_event_stream(event_stream);
+    vl_destroy_optimizer(optimizer);
+    return 0;
+}

--- a/cpp-client-reference/test/test_cxx11.cpp
+++ b/cpp-client-reference/test/test_cxx11.cpp
@@ -1,0 +1,3 @@
+#include "volition.h"
+
+auto main() -> int {}

--- a/cpp-client-reference/test/test_cxx98.cpp
+++ b/cpp-client-reference/test/test_cxx98.cpp
@@ -1,0 +1,3 @@
+#include "volition.h"
+
+int main () {}


### PR DESCRIPTION
# Volition C API

## Problem

Creating a Volition client in C++ currently requires building Protobuf and its dependencies. Even though this process has been streamlined in prior pull requests by leveraging Vcpkg integration with CMake, building Protobuf still requires a relatively modern C++ compiler. This makes adoption difficult for users using C or an older C++ toolchain.

## Solution

To ease user adoption, we decided to provide a C-based API for Volition. C has a stable ABI and is the de facto standard for API designs in many domains such as embedded systems, OS kernels, drivers, 3D graphics as well as FFI bindings for various programming languages. We have chosen to target C99, which is widely supported and a very common choice in the industry.

## Design References

In the design of this API, a number of projects were surveyed. Our main design criteria include ease of correct object lifetime management, memory safety as well as ensuring data type invariants are upheld.

### [Vulkan](https://www.vulkan.org/)

An industry standard API for high-performance 3D graphics backed by a consortium of GPU vendors. It aims to be lower-level and more efficient than its predecessor OpenGL.

The Vulkan API implements extensible polymorphism by using [tagged structure types](https://registry.khronos.org/vulkan/specs/1.3/html/chap3.html#fundamentals-validusage-sType). This gives the user full control over allocations of structure types. In C, however, it is difficult to ensure the tag matches the actual data type, making this somewhat error-prone for the API user.

Pros:
- User has full control over the memory allocation strategy.

Cons:
- Hard to ensure correct usage and memory safety.

### [libuv](https://libuv.org/)

A popular asynchronous IO framework used in projects including Node.js and the Julia programming language. The API is entirely callback-based. This architecture generally requires the user code to be divided into handler functions and separated from the data they operate on. Also, user-supplied callbacks must match pre-defined signatures and, therefore, cannot take or return arbitrary types. User data is type-erased and passed as a [`void` pointer](https://docs.libuv.org/en/v1.x/guide/basics.html#storing-context). The use of `void` pointers is a well understood limitation of callback-based designs and is also found in the Vulkan API for [allocation callbacks](https://registry.khronos.org/vulkan/specs/1.3/html/chap11.html#VkAllocationCallbacks).

Pros:
- Good type safety as the API controls the type dispatch. The only type cast required is for user data.

Cons:
- Imposes constraints on the structure of user code.
- Needs a side channel for user's own return types (e.g. by passing through user data).

### [Lua](https://www.lua.org/)

Lua is a popular scripting language in the gaming industry known for its portability and small code footprint. Its [API](https://www.lua.org/pil/24.html) largely revolves around a single opaque `lua_State` object that represents the state of the Lua VM. The host exchanges data with the Lua VM using a [stack](https://www.lua.org/pil/24.2.html) and makes API calls using data on this stack.

Stack-based data passing simplifies API function signatures as well as data ownership in the presence of garbage collection. But the user needs to ensure stack manipulation functions and other API functions are called in the correct order to obtain the desired results.

Pros:
- Easier to ensure memory safety due to the use of indices instead of raw pointers. Misuse often turns into recoverable type errors at run time.

Cons:
- Somewhat verbose due to stack manipulation calls.
- User still needs to ensure the values on stack are correctly manipulated to get the right results.

### [Python](https://www.python.org/)

The Python C API is largely [object-based](https://docs.python.org/3/c-api/intro.html#objects-types-and-reference-counts) and makes extensive use of dynamically allocated object types. The user is responsible for making `Py_INCREF` and `Py_DECREF` calls to adjust the [reference counts](https://docs.python.org/3/c-api/intro.html#reference-counts) for objects. Without [scope-based resource management](https://en.cppreference.com/w/cpp/language/raii), this can be error-prone.

Pros:
- Opaque object types provide a level of abstraction.
- More closely mimics object-oriented designs.

Cons:
- Manual reference count management is error-prone. Leaks and use-after-free of object pointers are both possible.

## Our Design

### Object Types

The Volition C API design features a few opaque object types.
- `vl_evaluable`
- `vl_event_stream`
- `vl_input`
- `vl_optimizer`
- `vl_result_stream`

Type erasure is done for `vl_optimizer`, `vl_event_stream` and `vl_result_stream` to encapsulate the underlying Protobuf-based implementation and for `vl_input` and `vl_evaluable` to achieve polymorphism. The lifetimes of these objects are managed by the corresponding `vl_create_*` and `vl_destroy_*` functions, similar to [object types](https://registry.khronos.org/vulkan/specs/1.3/html/chap3.html#fundamentals-objectmodel-lifetime) in the Vulkan API.

Currently, these are defined as pointers. But they can also be made indices. The Vulkan API distinguishes between dispatchable (pointer) and non-dispatchable (index-like) [handle types](https://registry.khronos.org/vulkan/specs/1.3/html/chap3.html#fundamentals-objectmodel-overview).

### Event Callbacks

The `vl_wait_event` function takes a `vl_event_stream` handle and a `vl_event_callbacks` structure, which contains pointers of user-defined handlers for the various optimizer event types.
```C
typedef struct vl_event_callbacks {
    void* user_data;
    vl_evaluation_request_callback on_evaluation_request;
    vl_evaluation_cancel_callback on_evaluation_cancel;
    vl_design_iteration_complete_callback on_design_iteration_complete;
    vl_optimization_abort_callback on_optimization_abort;
    vl_optimization_complete_callback on_optimization_complete;
} vl_event_callbacks;
```

`vl_wait_event` blocks until an event is received. Upon receiving an event, it performs type dispatch and calls the handler corresponding to the event type. This dispatch pattern is also similar to the type-safe [visit](https://en.cppreference.com/w/cpp/utility/variant/visit) function that operates on the [variant](https://en.cppreference.com/w/cpp/utility/variant) algebraic data type introduced in C++17.

Aside from type-safe switching, another advantage of callbacks is that the API becomes the caller of the handlers functions. This allows the API to control the lifetimes of non-user data passed to the handlers. 
```C
typedef void (*vl_evaluation_request_callback)(
    void* user_data,
    vl_evaluation_token token,
    double const* input);
```
With the exception of user data (which comes from the callbacks structure provided by the user) and `vl_*_token` types (which are concrete structure types with `const` fields to prevent accidental mutation), these parameters are only guaranteed to be valid for the duration of the call. The user must copy any data they are interested in to memory they own (e.g. for asynchronous computation).

`vl_evaluation_token` is valid until it is consumed by `vl_send_evaluation_result` or ` vl_send_evaluation_error`, which can be called within the handler or at a later time, depending on the concurrent run count setting.

### Error Handling

Our design defines a single status code type: `vl_status`. One aspect where our design differs from most other designs is that instead of returning status codes, functions that create handle instances return them directly:
```C
VLAPI_PUBLIC vl_optimizer vl_create_optimizer(char const* connection, vl_status* status)
    VLAPI_NOEXCEPT;
```
Null handles are returned on errors. And status codes become out parameters. The user can signal their disinterest in the status code by passing a `NULL` pointer for the status parameter. This is arguably less consistent, as some functions do return the status codes:
```C
VLAPI_PUBLIC vl_status vl_wait_event(vl_event_stream event_stream, vl_event_callbacks* callbacks);
```
But I find this slightly more ergonomic in common use cases.

### Exception-Safety

Most API functions do not throw C++ exceptions and are marked as such. But functions that take callbacks may propagate user exceptions from the callbacks. In the latter, the API guarantees that memory controlled by the API is never leaked or corrupted by user exceptions, as long as the API usage is valid.

## Future Works

Implement the API.

### C++ API

Optionally, we can provide a C++ API that provides the same functionality but handles resource management automatically using [RAII](https://en.cppreference.com/w/cpp/language/raii).
